### PR TITLE
Add BuildRequires to RHEL specfile

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,7 @@ James P.                roampune@gmail.com
 James Page              james.page@ubuntu.com
 Jarno Rajahalme         jrajahalme@nicira.com
 Jason Kölker            jason@koelker.net
+Jasper Capel            jasper@capel.tv
 Jean Tourrilhes         jt@hpl.hp.com
 Jeremy Stribling        strib@nicira.com
 Jesse Gross             jesse@nicira.com

--- a/rhel/openvswitch.spec.in
+++ b/rhel/openvswitch.spec.in
@@ -19,6 +19,7 @@ Release: 1
 Source: openvswitch-%{version}.tar.gz
 Buildroot: /tmp/openvswitch-rpm
 Requires: openvswitch-kmod, logrotate, python
+BuildRequires: openssl-devel
 
 %description
 Open vSwitch provides standard network bridging functions and


### PR DESCRIPTION
Added a build-time dependency on openssl-devel, so you can easily build
a source RPM and then pass it into mock for building in a clean build
environment (without manually having to install the buildrequires).
