### PR TITLE
datapath/linux: add KCFLAGS var to modules Makefile.main.in

### DIFF
--- a/datapath/linux/Makefile.main.in
+++ b/datapath/linux/Makefile.main.in
@@ -68,10 +68,10 @@ ifeq (,$(wildcard $(CONFIG_FILE)))
 endif
 
 default:
-	$(MAKE) -C $(KSRC) M=$(builddir) modules
+	$(MAKE) -C $(KSRC) M=$(builddir) $(KCFLAGS) modules
 
 modules_install:
-	$(MAKE) -C $(KSRC) M=$(builddir) modules_install
+	$(MAKE) -C $(KSRC) M=$(builddir) $(KCFLAGS) modules_install
 	depmod `sed -n 's/#define UTS_RELEASE "\([^"]*\)"/\1/p' $(KSRC)/include/generated/utsrelease.h`
 endif
 


### PR DESCRIPTION
This is mostly required because of GCC 4.9 which seems
to error out with:
  openvswitch/datapath/linux/datapath.c:2108:10:
       error: macro "DATE" might prevent reproducible builds

We would have wanted to add '-Wno-error=date-time' directly
but that would be too specific, so we decided to add
a generic make flag and configure it with what we need.

Will reference this issue : https://github.com/openwrt/packages/issues/457
This is the starting point/reason for this change.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>