### PR TITLE
Fixed formatting for command block

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1182,8 +1182,8 @@ A: By default, Open vSwitch will use the assigned IANA port for VXLAN, which
    manually on a per-VXLAN tunnel basis. An example of this configuration is
    provided below.
 
-   ovs-vsctl add-br br0
-   ovs-vsctl add-port br0 vxlan1 -- set interface vxlan1
+       ovs-vsctl add-br br0
+       ovs-vsctl add-port br0 vxlan1 -- set interface vxlan1
        type=vxlan options:remote_ip=192.168.1.2 options:key=flow
        options:dst_port=8472
 


### PR DESCRIPTION
Hi, I just read through the FAQ and noticed the formatting on one of the examples was not correct. This is a small fix for that.

For visual diff please see the rendered markdown versions here:
https://github.com/openvswitch/ovs/blob/master/FAQ.md#q-what-destination-udp-port-does-the-vxlan-implementation-in-open-vswitch
https://github.com/scorpiion/ovs/blob/master/FAQ.md#q-what-destination-udp-port-does-the-vxlan-implementation-in-open-vswitch

Signed-off-by: Robert Åkerblom-Andersson Robert.nr1@gmail.com
