### PR TITLE
Use ifquery for finding the interfaces

### DIFF
--- a/debian/openvswitch-switch.init
+++ b/debian/openvswitch-switch.init
@@ -33,7 +33,7 @@ test -e /etc/default/openvswitch-switch && . /etc/default/openvswitch-switch
 network_interfaces () {
     INTERFACES="/etc/network/interfaces"
     [ -e "${INTERFACES}" ] || return
-    bridges=`awk '{ if ($1 == "allow-ovs") { print $2; } }' "${INTERFACES}"`
+    bridges=`ifquery --allow ovs --list`
     [ -n "${bridges}" ] && $1 --allow=ovs ${bridges}
 }
 


### PR DESCRIPTION
When using interfaces.d/<foobar>, interfaces are not picked up. Let ifquery figure out the format of the interfaces files for us.
