### PR TITLE
Add support to control Reports forwarding

### DIFF
--- a/lib/mcast-snooping.c
+++ b/lib/mcast-snooping.c
@@ -38,6 +38,8 @@
 COVERAGE_DEFINE(mcast_snooping_learned);
 COVERAGE_DEFINE(mcast_snooping_expired);
 
+static struct mcast_port_bundle *
+mcast_snooping_port_lookup(struct ovs_list *list, void *port);
 static struct mcast_mrouter_bundle *
 mcast_snooping_mrouter_lookup(struct mcast_snooping *ms, uint16_t vlan,
                               void *port)
@@ -382,7 +384,7 @@ mcast_snooping_add_group(struct mcast_snooping *ms, ovs_be32 ip4,
 
     /* Avoid duplicate packets. */
     if (mcast_snooping_mrouter_lookup(ms, vlan, port)
-        || mcast_snooping_fport_lookup(ms, vlan, port)) {
+        || mcast_snooping_port_lookup(&ms->fport_list, port)) {
         return false;
     }
 
@@ -488,7 +490,7 @@ mcast_snooping_add_mrouter(struct mcast_snooping *ms, uint16_t vlan,
     struct mcast_mrouter_bundle *mrouter;
 
     /* Avoid duplicate packets. */
-    if (mcast_snooping_fport_lookup(ms, vlan, port)) {
+    if (mcast_snooping_port_lookup(&ms->fport_list, port)) {
         return false;
     }
 
@@ -515,22 +517,22 @@ mcast_snooping_flush_mrouter(struct mcast_mrouter_bundle *mrouter)
     free(mrouter);
 }
 
-/* Flood ports. */
+/* Ports */
 
-static struct mcast_fport_bundle *
-mcast_fport_from_list_node(struct ovs_list *list)
+static struct mcast_port_bundle *
+mcast_port_from_list_node(struct ovs_list *list)
 {
-    return CONTAINER_OF(list, struct mcast_fport_bundle, fport_node);
+    return CONTAINER_OF(list, struct mcast_port_bundle, node);
 }
 
 /* If the list is not empty, stores the fport in '*f' and returns true.
  * Otherwise, if the list is empty, stores NULL in '*f' and return false. */
 static bool
-fport_get(const struct mcast_snooping *ms, struct mcast_fport_bundle **f)
-    OVS_REQ_RDLOCK(ms->rwlock)
+mcast_snooping_port_get(const struct ovs_list *list,
+                        struct mcast_port_bundle **f)
 {
-    if (!list_is_empty(&ms->fport_list)) {
-        *f = mcast_fport_from_list_node(ms->fport_list.next);
+    if (!list_is_empty(list)) {
+        *f = mcast_port_from_list_node(list->next);
         return true;
     } else {
         *f = NULL;
@@ -538,53 +540,51 @@ fport_get(const struct mcast_snooping *ms, struct mcast_fport_bundle **f)
     }
 }
 
-struct mcast_fport_bundle *
-mcast_snooping_fport_lookup(struct mcast_snooping *ms, uint16_t vlan,
-                            void *port)
-    OVS_REQ_RDLOCK(ms->rwlock)
+static struct mcast_port_bundle *
+mcast_snooping_port_lookup(struct ovs_list *list, void *port)
 {
-    struct mcast_fport_bundle *fport;
+    struct mcast_port_bundle *pbundle;
 
-    LIST_FOR_EACH (fport, fport_node, &ms->fport_list) {
-        if (fport->vlan == vlan && fport->port == port) {
-            return fport;
+    LIST_FOR_EACH (pbundle, node, list) {
+        if (pbundle->port == port) {
+            return pbundle;
         }
     }
     return NULL;
 }
 
 static void
-mcast_snooping_add_fport(struct mcast_snooping *ms, uint16_t vlan, void *port)
-    OVS_REQ_WRLOCK(ms->rwlock)
+mcast_snooping_add_port(struct ovs_list *list, void *port)
 {
-    struct mcast_fport_bundle *fport;
+    struct mcast_port_bundle *pbundle;
 
-    fport = xmalloc(sizeof *fport);
-    fport->vlan = vlan;
-    fport->port = port;
-    list_insert(&ms->fport_list, &fport->fport_node);
+    pbundle = xmalloc(sizeof *pbundle);
+    pbundle->port = port;
+    list_insert(list, &pbundle->node);
 }
 
 static void
-mcast_snooping_flush_fport(struct mcast_fport_bundle *fport)
+mcast_snooping_flush_port(struct mcast_port_bundle *pbundle)
 {
-    list_remove(&fport->fport_node);
-    free(fport);
+    list_remove(&pbundle->node);
+    free(pbundle);
 }
 
+
+/* Flood ports. */
 void
-mcast_snooping_set_port_flood(struct mcast_snooping *ms, uint16_t vlan,
-                              void *port, bool flood)
+mcast_snooping_set_port_flood(struct mcast_snooping *ms, void *port,
+                              bool flood)
     OVS_REQ_WRLOCK(ms->rwlock)
 {
-    struct mcast_fport_bundle *fport;
+    struct mcast_port_bundle *fbundle;
 
-    fport = mcast_snooping_fport_lookup(ms, vlan, port);
-    if (flood && !fport) {
-        mcast_snooping_add_fport(ms, vlan, port);
+    fbundle = mcast_snooping_port_lookup(&ms->fport_list, port);
+    if (flood && !fbundle) {
+        mcast_snooping_add_port(&ms->fport_list, port);
         ms->need_revalidate = true;
-    } else if (!flood && fport) {
-        mcast_snooping_flush_fport(fport);
+    } else if (!flood && fbundle) {
+        mcast_snooping_flush_port(fbundle);
         ms->need_revalidate = true;
     }
 }
@@ -628,7 +628,7 @@ mcast_snooping_flush__(struct mcast_snooping *ms)
 {
     struct mcast_group *grp;
     struct mcast_mrouter_bundle *mrouter;
-    struct mcast_fport_bundle *fport;
+    struct mcast_port_bundle *pbundle;
 
     while (group_get_lru(ms, &grp)) {
         mcast_snooping_flush_group(ms, grp);
@@ -640,8 +640,8 @@ mcast_snooping_flush__(struct mcast_snooping *ms)
         mcast_snooping_flush_mrouter(mrouter);
     }
 
-    while (fport_get(ms, &fport)) {
-        mcast_snooping_flush_fport(fport);
+    while (mcast_snooping_port_get(&ms->fport_list, &pbundle)) {
+        mcast_snooping_flush_port(pbundle);
     }
 }
 

--- a/lib/mcast-snooping.h
+++ b/lib/mcast-snooping.h
@@ -87,17 +87,17 @@ struct mcast_mrouter_bundle {
     void *port OVS_GUARDED;
 };
 
-/* The bundle to be flooded with multicast traffic.
+/* The bundle to send multicast traffic.
  * Guarded by owning 'mcast_snooping''s rwlock */
-struct mcast_fport_bundle {
-    /* Node in parent struct mcast_snooping fport_list. */
-    struct ovs_list fport_node;
+struct mcast_port_bundle {
+    /* Node in parent struct mcast_snooping. */
+    struct ovs_list node;
 
     /* VLAN tag. */
     uint16_t vlan;
 
     /* Learned port. */
-    void *port OVS_GUARDED;
+    void *port;
 };
 
 /* Multicast snooping table. */
@@ -113,7 +113,7 @@ struct mcast_snooping {
      * front, most recently used at the back. */
     struct ovs_list mrouter_lru OVS_GUARDED;
 
-    /* Contains struct mcast_fport_bundle to be flooded with multicast
+    /* Contains struct mcast_port_bundle to be flooded with multicast
      * packets in no special order. */
     struct ovs_list fport_list OVS_GUARDED;
 
@@ -160,8 +160,8 @@ void mcast_snooping_set_max_entries(struct mcast_snooping *ms,
 bool
 mcast_snooping_set_flood_unreg(struct mcast_snooping *ms, bool enable)
     OVS_REQ_WRLOCK(ms->rwlock);
-void mcast_snooping_set_port_flood(struct mcast_snooping *ms, uint16_t vlan,
-                                   void *port, bool flood)
+void mcast_snooping_set_port_flood(struct mcast_snooping *ms, void *port,
+                                   bool flood)
     OVS_REQ_WRLOCK(ms->rwlock);
 
 /* Lookup. */
@@ -180,10 +180,6 @@ bool mcast_snooping_leave_group(struct mcast_snooping *ms, ovs_be32 ip4,
 bool mcast_snooping_add_mrouter(struct mcast_snooping *ms, uint16_t vlan,
                                 void *port)
     OVS_REQ_WRLOCK(ms->rwlock);
-struct mcast_fport_bundle *
-mcast_snooping_fport_lookup(struct mcast_snooping *ms, uint16_t vlan,
-                            void *port)
-    OVS_REQ_RDLOCK(ms->rwlock);
 bool mcast_snooping_is_query(ovs_be16 igmp_type);
 bool mcast_snooping_is_membership(ovs_be16 igmp_type);
 

--- a/lib/mcast-snooping.h
+++ b/lib/mcast-snooping.h
@@ -87,7 +87,7 @@ struct mcast_mrouter_bundle {
     void *port OVS_GUARDED;
 };
 
-/* The bundle to send multicast traffic.
+/* The bundle to send multicast traffic or Reports.
  * Guarded by owning 'mcast_snooping''s rwlock */
 struct mcast_port_bundle {
     /* Node in parent struct mcast_snooping. */
@@ -116,6 +116,10 @@ struct mcast_snooping {
     /* Contains struct mcast_port_bundle to be flooded with multicast
      * packets in no special order. */
     struct ovs_list fport_list OVS_GUARDED;
+
+    /* Contains struct mcast_port_bundle to forward Reports in
+     * no special order. */
+    struct ovs_list rport_list OVS_GUARDED;
 
     /* Secret for randomizing hash table. */
     uint32_t secret;
@@ -162,6 +166,9 @@ mcast_snooping_set_flood_unreg(struct mcast_snooping *ms, bool enable)
     OVS_REQ_WRLOCK(ms->rwlock);
 void mcast_snooping_set_port_flood(struct mcast_snooping *ms, void *port,
                                    bool flood)
+    OVS_REQ_WRLOCK(ms->rwlock);
+void mcast_snooping_set_port_flood_reports(struct mcast_snooping *ms,
+                                           void *port, bool flood)
     OVS_REQ_WRLOCK(ms->rwlock);
 
 /* Lookup. */

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -1982,7 +1982,7 @@ update_mcast_snooping_table(const struct xbridge *xbridge,
     struct mcast_snooping *ms = xbridge->ms;
     struct xlate_cfg *xcfg;
     struct xbundle *mcast_xbundle;
-    struct mcast_fport_bundle *fport;
+    struct mcast_port_bundle *fport;
 
     /* Don't learn the OFPP_NONE port. */
     if (in_xbundle == &ofpp_none_bundle) {
@@ -1993,7 +1993,7 @@ update_mcast_snooping_table(const struct xbridge *xbridge,
     mcast_xbundle = NULL;
     ovs_rwlock_wrlock(&ms->rwlock);
     xcfg = ovsrcu_get(struct xlate_cfg *, &xcfgp);
-    LIST_FOR_EACH(fport, fport_node, &ms->fport_list) {
+    LIST_FOR_EACH(fport, node, &ms->fport_list) {
         mcast_xbundle = xbundle_lookup(xcfg, fport->port);
         if (mcast_xbundle == in_xbundle) {
             break;
@@ -2066,11 +2066,11 @@ xlate_normal_mcast_send_fports(struct xlate_ctx *ctx,
     OVS_REQ_RDLOCK(ms->rwlock)
 {
     struct xlate_cfg *xcfg;
-    struct mcast_fport_bundle *fport;
+    struct mcast_port_bundle *fport;
     struct xbundle *mcast_xbundle;
 
     xcfg = ovsrcu_get(struct xlate_cfg *, &xcfgp);
-    LIST_FOR_EACH(fport, fport_node, &ms->fport_list) {
+    LIST_FOR_EACH(fport, node, &ms->fport_list) {
         mcast_xbundle = xbundle_lookup(xcfg, fport->port);
         if (mcast_xbundle && mcast_xbundle != in_xbundle) {
             xlate_report(ctx, "forwarding to mcast flood port");

--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -3144,16 +3144,19 @@ set_mcast_snooping(struct ofproto *ofproto_,
     return 0;
 }
 
-/* Configures multicast snooping port's flood setting on 'ofproto'. */
+/* Configures multicast snooping port's flood settings on 'ofproto'. */
 static int
-set_mcast_snooping_port(struct ofproto *ofproto_, void *aux, bool flood)
+set_mcast_snooping_port(struct ofproto *ofproto_, void *aux,
+                        const struct ofproto_mcast_snooping_port_settings *s)
 {
     struct ofproto_dpif *ofproto = ofproto_dpif_cast(ofproto_);
     struct ofbundle *bundle = bundle_lookup(ofproto, aux);
 
-    if (ofproto->ms) {
+    if (ofproto->ms && s) {
         ovs_rwlock_wrlock(&ofproto->ms->rwlock);
-        mcast_snooping_set_port_flood(ofproto->ms, bundle, flood);
+        mcast_snooping_set_port_flood(ofproto->ms, bundle, s->flood);
+        mcast_snooping_set_port_flood_reports(ofproto->ms, bundle,
+                                              s->flood_reports);
         ovs_rwlock_unlock(&ofproto->ms->rwlock);
     }
     return 0;

--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -3153,8 +3153,7 @@ set_mcast_snooping_port(struct ofproto *ofproto_, void *aux, bool flood)
 
     if (ofproto->ms) {
         ovs_rwlock_wrlock(&ofproto->ms->rwlock);
-        mcast_snooping_set_port_flood(ofproto->ms, bundle->vlan, bundle,
-                                      flood);
+        mcast_snooping_set_port_flood(ofproto->ms, bundle, flood);
         ovs_rwlock_unlock(&ofproto->ms->rwlock);
     }
     return 0;

--- a/ofproto/ofproto-provider.h
+++ b/ofproto/ofproto-provider.h
@@ -1588,14 +1588,15 @@ struct ofproto_class {
 
     /* Configures multicast snooping port's flood setting on 'ofproto'.
      *
-     * All multicast traffic is sent to struct port 'aux' in 'ofproto'
-     * if 'flood' is true. Otherwise, struct port 'aux' is an ordinary
-     * switch port.
+     * If 's' is nonnull, this function updates multicast snooping
+     * configuration to 's' in 'ofproto'.
+     *
+     * If 's' is NULL, this function doesn't change anything.
      *
      * An implementation that does not support multicast snooping may set
      * it to NULL or return EOPNOTSUPP. */
     int (*set_mcast_snooping_port)(struct ofproto *ofproto_, void *aux,
-                                   bool flood);
+                          const struct ofproto_mcast_snooping_port_settings *s);
 
 /* Linux VLAN device support (e.g. "eth0.10" for VLAN 10.)
  *

--- a/ofproto/ofproto.c
+++ b/ofproto/ofproto.c
@@ -721,15 +721,15 @@ ofproto_set_mcast_snooping(struct ofproto *ofproto,
             : EOPNOTSUPP);
 }
 
-/* Configures multicast snooping flood setting on 'ofp_port' of 'ofproto'.
+/* Configures multicast snooping flood settings on 'ofp_port' of 'ofproto'.
  *
  * Returns 0 if successful, otherwise a positive errno value.*/
 int
-ofproto_port_set_mcast_snooping(struct ofproto *ofproto, void *aux, bool flood)
+ofproto_port_set_mcast_snooping(struct ofproto *ofproto, void *aux,
+                           const struct ofproto_mcast_snooping_port_settings *s)
 {
     return (ofproto->ofproto_class->set_mcast_snooping_port
-            ? ofproto->ofproto_class->set_mcast_snooping_port(ofproto, aux,
-                                                              flood)
+            ? ofproto->ofproto_class->set_mcast_snooping_port(ofproto, aux, s)
             : EOPNOTSUPP);
 }
 

--- a/ofproto/ofproto.h
+++ b/ofproto/ofproto.h
@@ -182,6 +182,11 @@ struct ofproto_mcast_snooping_settings {
     unsigned int max_entries;   /* Size of the multicast snooping table. */
 };
 
+struct ofproto_mcast_snooping_port_settings {
+    bool flood;                 /* If true, flood multicast traffic */
+    bool flood_reports;         /* If true, flood Reports traffic */
+};
+
 /* How the switch should act if the controller cannot be contacted. */
 enum ofproto_fail_mode {
     OFPROTO_FAIL_SECURE,        /* Preserve flow table. */
@@ -303,7 +308,7 @@ void ofproto_set_mac_table_config(struct ofproto *, unsigned idle_time,
 int ofproto_set_mcast_snooping(struct ofproto *ofproto,
                               const struct ofproto_mcast_snooping_settings *s);
 int ofproto_port_set_mcast_snooping(struct ofproto *ofproto, void *aux,
-                                    bool flood);
+                          const struct ofproto_mcast_snooping_port_settings *s);
 void ofproto_set_threads(int n_handlers, int n_revalidators);
 void ofproto_set_n_dpdk_rxqs(int n_rxqs);
 void ofproto_set_cpu_mask(const char *cmask);

--- a/utilities/ovs-vsctl.8.in
+++ b/utilities/ovs-vsctl.8.in
@@ -995,9 +995,13 @@ unregistered packets on bridge \fBbr0\fR.
 .IP
 .B "ovs\-vsctl set Bridge br0 other_config:mcast-snooping-disable-flood-unregistered=true"
 .PP
-Enable flooding of multicast packets on a specific port.
+Enable flooding of multicast packets (except Reports) on a specific port.
 .IP
 .B "ovs\-vsctl set Port eth1 other_config:mcast-snooping-flood=true"
+.PP
+Enable flooding of Reports on a specific port.
+.IP
+.B "ovs\-vsctl set Port eth1 other_config:mcast-snooping-flood-reports=true"
 .PP
 Deconfigure multicasting snooping from above:
 .IP

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -1896,9 +1896,12 @@ bridge_configure_mcast_snooping(struct bridge *br)
         }
 
         HMAP_FOR_EACH (port, hmap_node, &br->ports) {
-            bool flood = smap_get_bool(&port->cfg->other_config,
+            struct ofproto_mcast_snooping_port_settings port_s;
+            port_s.flood = smap_get_bool(&port->cfg->other_config,
                                        "mcast-snooping-flood", false);
-            if (ofproto_port_set_mcast_snooping(br->ofproto, port, flood)) {
+            port_s.flood_reports = smap_get_bool(&port->cfg->other_config,
+                                       "mcast-snooping-flood-reports", false);
+            if (ofproto_port_set_mcast_snooping(br->ofproto, port, &port_s)) {
                 VLOG_ERR("port %s: could not configure mcast snooping",
                          port->name);
             }

--- a/vswitchd/vswitch.xml
+++ b/vswitchd/vswitch.xml
@@ -1419,7 +1419,14 @@
       <column name="other_config" key="mcast-snooping-flood"
               type='{"type": "boolean"}'>
         <p>
-          If set to <code>true</code>, multicast packets are unconditionally
+          If set to <code>true</code>, multicast packets (except Reports) are
+          unconditionally forwarded to the specific port.
+        </p>
+      </column>
+      <column name="other_config" key="mcast-snooping-flood-reports"
+              type='{"type": "boolean"}'>
+        <p>
+          If set to <code>true</code>, multicast Reports are unconditionally
           forwarded to the specific port.
         </p>
       </column>


### PR DESCRIPTION
The RFC4541 section 2.1.1 item 1 allows the snooping switch
to provide an administrative control to allow Report messages
to be flooded to ports not connected to multicast routers.

This is useful for tunnels and patch ports in order to send
Reports across switches.