### PR TITLE
Preserve IPv6 link-local address on interface save

### DIFF
--- a/utilities/ovs-save
+++ b/utilities/ovs-save
@@ -100,9 +100,10 @@ save_interfaces () {
                         continue 2
                         ;;
                     scope)
-                        if test "$2" = link; then
+                        if test "$2" = link -a "$family" != inet6; then
                             # Omit route derived from IP address, e.g.
-                            # 172.16.0.0/16 derived from 172.16.12.34.
+                            # 172.16.0.0/16 derived from 172.16.12.34,
+                            # but preserve IPv6 link-local address.
                             continue 2
                         fi
                         ;;


### PR DESCRIPTION
If IPv6 link-local address is removed from interface, it is unable to
receive any IPv6 packets, including Route Advertisements.

In save_interface only skip IPv4 "scope link" addresses.