### PR TITLE
Updated openvswitch-fedora.spec file - fixed RPM build errors: Installed (but unpackaged) file(s) found.

### DIFF
--- a/rhel/openvswitch-fedora.spec.in
+++ b/rhel/openvswitch-fedora.spec.in
@@ -200,6 +200,8 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root)
+%{_sysconfdir}/bash_completion.d/ovs-appctl-bashcomp.bash
+%{_sysconfdir}/bash_completion.d/ovs-vsctl-bashcomp.bash
 %dir %{_sysconfdir}/openvswitch
 %config %ghost %{_sysconfdir}/openvswitch/conf.db
 %config %ghost %{_sysconfdir}/openvswitch/system-id.conf


### PR DESCRIPTION
On exec rpmbuild -ba openvswitch-fedora.spec displayed:

error: Installed (but unpackaged) file(s) found:
   /etc/bash_completion.d/ovs-appctl-bashcomp.bash
   /etc/bash_completion.d/ovs-vsctl-bashcomp.bash

RPM build errors:
    Installed (but unpackaged) file(s) found:
   /etc/bash_completion.d/ovs-appctl-bashcomp.bash
   /etc/bash_completion.d/ovs-vsctl-bashcomp.bash

/etc/bash_completion.d/ovs-appctl-bashcomp.bash and
/etc/bash_completion.d/ovs-vsctl-bashcomp.bash added to files list.