### PR TITLE
MTU parameter for the network docker interface

### DIFF
--- a/utilities/ovs-docker
+++ b/utilities/ovs-docker
@@ -67,7 +67,8 @@ add_port () {
     CONTAINER="$3"
     ADDRESS="$4"
     GATEWAY="$5"
-
+    MTU="$6"
+    
     if [ "$#" -lt 3 ]; then
         usage
         exit 1
@@ -115,6 +116,11 @@ add_port () {
     # Move "${PORTNAME}_c" inside the container and changes its name.
     ip link set "${PORTNAME}_c" netns "$PID"
     ip netns exec "$PID" ip link set dev "${PORTNAME}_c" name "$INTERFACE"
+    
+    # Change the MTU
+    if [ -n "$MTU" ]; then
+        ip netns exec "$PID" ip link set dev "$INTERFACE" mtu "$MTU"
+    fi
     ip netns exec "$PID" ip link set "$INTERFACE" up
 
     if [ -n "$ADDRESS" ]; then
@@ -190,14 +196,15 @@ ${UTIL}: Performs integration of Open vSwitch with Docker.
 usage: ${UTIL} COMMAND
 
 Commands:
-  add-port BRIDGE INTERFACE CONTAINER [ADDRESS [GATEWAY]]
+  add-port BRIDGE INTERFACE CONTAINER [ADDRESS [GATEWAY [MTU]]]
                     Adds INTERFACE inside CONTAINER and connects it as a port
                     in Open vSwitch BRIDGE. Optionally, sets ADDRESS on
                     INTERFACE. ADDRESS can include a '/' to represent network
                     prefix length. Along with ADDRESS, optionally set the
-                    default gateway for the container. e.g.:
+                    default gateway for the container, optionally set the
+                    mtu for the network container interface. e.g.:
                     ${UTIL} add-port br-int eth1 c474a0e2830e 192.168.1.2/24 \
-                        192.168.1.1
+                        192.168.1.1 1500
   del-port BRIDGE INTERFACE CONTAINER
                     Deletes INTERFACE inside CONTAINER and removes its
                     connection to Open vSwitch BRIDGE. e.g.:


### PR DESCRIPTION
Signed-off-by: Aurélien Poulain aurepoulain@viacesi.fr
I would like to submit a change because of a problem I encounter.

Problem:
I use a GRE tunnel between several hosts (each host have containers). I can ping containers from one host to another. When I start an iperf, the TCP connection is established, but the MTU on the container blocks the data because the MTU is too high. Indeed, the MTU appears to be 1500 for the container’s interface while it is limited by the GRE tunnel. The GRE tunnels need to encapsulate several protocols:
•	Ethernet: 14 bytes
•	IPv4: 20 bytes
•	GRE 4 bytes The total overhead is 38 bytes on the physical interface, so the resulting PDU size is 1462 bytes (out of a regular 1500 MTU based interface).

Solution:
I would like to add the possibility to set the MTU parameter for the created network container interface, because it’s not possible to change the MTU inside the container, we have this error:
“Unable to resolve host ######
RTNETLINK answers : Operation not permitted”
We cannot use the network namespace after the ovs-docker script, we have this error:
“cannot open network namespace “#####”: No such file or directory”
In the submitted changes, I have added an MTU argument for the add_port command and I have added a condition to check if the MTU value is present to change the MTU for the interface to the new specified value.