### PR TITLE
netdev-bsd: include net/bpf.h

### DIFF
--- a/lib/netdev-bsd.c
+++ b/lib/netdev-bsd.c
@@ -26,6 +26,7 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/sockio.h>
+#include <net/bpf.h>
 #include <ifaddrs.h>
 #include <pcap/pcap.h>
 #include <net/if.h>


### PR DESCRIPTION
The documentation says it is required to use bpf ioctls on both
NetBSD and FreeBSD. It causes a compile time failure on FreeBSD 10.