### PR TITLE
datapath: do not add vlan_hwaccel_push_inside() for kernel >= 3.18.13

### DIFF
--- a/datapath/linux/compat/include/linux/if_vlan.h
+++ b/datapath/linux/compat/include/linux/if_vlan.h
@@ -52,7 +52,7 @@ static inline struct sk_buff *rpl_vlan_insert_tag_set_proto(struct sk_buff *skb,
 }
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,19,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,13)
 /*
  * __vlan_hwaccel_push_inside - pushes vlan tag to the payload
  * @skb: skbuff to tag


### PR DESCRIPTION
The vlan_hwaccel_push_inside() function was backported in this commit
to kernel 3.18.13:

commit a67e2e88342accd49587d9bad72f6dabd7673f7c
Author: Jiri Pirko <jiri@resnulli.us>
Date:   Wed Nov 19 14:04:59 2014 +0100

    vlan: introduce *vlan_hwaccel_push_inside helpers

    [ Upstream commit 5968250c868ceee680aa77395b24e6ddcae17d36 ]

Without this patch compilation breaks on kernel >= 3.18.13

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>