### PR TITLE
Disabling the SSL Session caching/reuse

### DIFF
--- a/lib/stream-ssl.c
+++ b/lib/stream-ssl.c
@@ -971,6 +971,7 @@ do_ssl_init(void)
     SSL_CTX_set_mode(ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
     SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
                        NULL);
+    SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
 
     return 0;
 }


### PR DESCRIPTION
For reuse of SSL sessions, the Server is supposed to set an unique SSL context session ID by using function SSL_CTX_set_session_id_context().
Refer: https://www.openssl.org/docs/ssl/SSL_CTX_set_session_id_context.html

As the current code doesn't configure unique SSL context session ID, disabling the SSL session caching/reuse.

Without this fix, we will get below error from OpenSSL when client tries to reuse the SSL Session:
stream_ssl|WARN|SSL_accept: error:140D9115:SSL routines:SSL_GET_PREV_SESSION:session id context uninitialized


The issue is easily reproducible when "ovs-testcontroller" is used to test some flows. When I disconnect my custom Openflow client, and reconnect back, the "ovs-testcontroller" starts throwing the reported error and disconnects with my client.

There are quite a few other opensource projects which use OpenSSL and doesn't set the SSL Session ID flag nor disabled the SSL caching. They made fixes in their code accordingly.

e.g https://jira.mongodb.org/browse/SERVER-17022
http://dev.eclipse.org/mhonarc/lists/mosquitto-dev/msg00173.html
tejr/ngircd@b71a0dd