### PR TITLE
ovs-bugtool: remove argmuent of "ovs-appctl dpif/show"

### DIFF
--- a/utilities/bugtool/ovs-bugtool-ovs-appctl-dpif
+++ b/utilities/bugtool/ovs-bugtool-ovs-appctl-dpif
@@ -16,10 +16,10 @@
 #
 # Copyright (C) 2013 Nicira, Inc.
 
+echo "ovs-appctl dpif/show"
+ovs-appctl dpif/show
 for bridge in `ovs-vsctl -- --real list-br`
 do
-    echo "ovs-appctl dpif/show ${bridge}"
-    ovs-appctl dpif/show "${bridge}"
     echo "ovs-appctl dpif/dump-flows -m ${bridge}"
     ovs-appctl dpif/dump-flows -m "$bridge"
     echo ""


### PR DESCRIPTION
"ovs-appctl dpif/show" no longer takes any argument after commit dc54ef36.

Signed-off-by: Huanle Han <hanxueluo@gmail.com>