### PR TITLE
ovs-appctl: register unixctl commands in the beginning

### DIFF
--- a/lib/bfd.h
+++ b/lib/bfd.h
@@ -43,6 +43,7 @@ bool bfd_should_process_flow(const struct bfd *, const struct flow *,
 void bfd_process_packet(struct bfd *, const struct flow *,
                         const struct dp_packet *);
 
+void bfd_init(void);
 struct bfd *bfd_configure(struct bfd *, const char *name,
                           const struct smap *smap,
                           struct netdev *netdev);

--- a/ofproto/ofproto-dpif-upcall.c
+++ b/ofproto/ofproto-dpif-upcall.c
@@ -304,12 +304,10 @@ static upcall_callback upcall_cb;
 static atomic_bool enable_megaflows = ATOMIC_VAR_INIT(true);
 static atomic_bool enable_ufid = ATOMIC_VAR_INIT(true);
 
-struct udpif *
-udpif_create(struct dpif_backer *backer, struct dpif *dpif)
+void
+udpif_init(void)
 {
     static struct ovsthread_once once = OVSTHREAD_ONCE_INITIALIZER;
-    struct udpif *udpif = xzalloc(sizeof *udpif);
-
     if (ovsthread_once_start(&once)) {
         unixctl_command_register("upcall/show", "", 0, 0, upcall_unixctl_show,
                                  NULL);
@@ -329,6 +327,12 @@ udpif_create(struct dpif_backer *backer, struct dpif *dpif)
                                  upcall_unixctl_purge, NULL);
         ovsthread_once_done(&once);
     }
+}
+
+struct udpif *
+udpif_create(struct dpif_backer *backer, struct dpif *dpif)
+{
+    struct udpif *udpif = xzalloc(sizeof *udpif);
 
     udpif->dpif = dpif;
     udpif->backer = backer;

--- a/ofproto/ofproto-dpif-upcall.h
+++ b/ofproto/ofproto-dpif-upcall.h
@@ -28,6 +28,7 @@ struct simap;
  * them.  Additionally, it's responsible for maintaining the datapath flow
  * table. */
 
+void udpif_init(void);
 struct udpif *udpif_create(struct dpif_backer *, struct dpif *);
 void udpif_run(struct udpif *udpif);
 void udpif_set_threads(struct udpif *, size_t n_handlers,

--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -446,6 +446,9 @@ init(const struct shash *iface_hints)
 
         shash_add(&init_ofp_ports, node->name, new_hint);
     }
+
+    ofproto_unixctl_init();
+    udpif_init();
 }
 
 static void
@@ -1270,8 +1273,6 @@ construct(struct ofproto *ofproto_)
     ovs_mutex_init(&ofproto->vsp_mutex);
 
     guarded_list_init(&ofproto->pins);
-
-    ofproto_unixctl_init();
 
     hmap_init(&ofproto->vlandev_map);
     hmap_init(&ofproto->realdev_vid_map);

--- a/ofproto/ofproto.c
+++ b/ofproto/ofproto.c
@@ -383,6 +383,8 @@ ofproto_init(const struct shash *iface_hints)
     for (i = 0; i < n_ofproto_classes; i++) {
         ofproto_classes[i]->init(&init_ofp_ports);
     }
+
+    ofproto_unixctl_init();
 }
 
 /* 'type' should be a normalized datapath type, as returned by
@@ -510,8 +512,6 @@ ofproto_create(const char *datapath_name, const char *datapath_type,
     int i;
 
     *ofprotop = NULL;
-
-    ofproto_unixctl_init();
 
     datapath_type = ofproto_normalize_type(datapath_type);
     class = ofproto_class_find__(datapath_type);

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -473,6 +473,7 @@ bridge_init(const char *remote)
     lacp_init();
     bond_init();
     cfm_init();
+    bfd_init();
     ovs_numa_init();
     stp_init();
     lldp_init();


### PR DESCRIPTION
Some commands of ovs-appctl were lazily registered when first
bridg or bfd was added. Before that, calling these commands raised a
error("xxx is not a valid command"). The problem commangs included
"bfd/...", "upcall/...","dpif/...","fdb/..." and so on.

Fix this by moving the register into the "bridge_init" and
"bridge_init_ofproto". All commands are registered at the moment
ovs-vswitchd starts.

Signed-off-by: Huanle Han <hanxueluo@gmail.com>