### PR TITLE
ovs-sandbox: assign default value  to ${MAKE}

### DIFF
--- a/tutorial/ovs-sandbox
+++ b/tutorial/ovs-sandbox
@@ -301,7 +301,7 @@ OVS_SYSCONFDIR=$sandbox; export OVS_SYSCONFDIR
 
 if $built; then
     # Easy access to OVS manpages.
-    (cd "$builddir" && ${MAKE} install-man mandir="$sandbox"/man)
+    (cd "$builddir" && ${MAKE-make} install-man mandir="$sandbox"/man)
     MANPATH=$sandbox/man:; export MANPATH
 fi
 


### PR DESCRIPTION
When run ovs-sandbox directly from the tutorial directory (the second method
in Tutorial.md), the following result show up:

$ ./ovs-sandbox -b /media/sda6/network/ovs/build
./ovs-sandbox: line 304: install-man: command not found

The reason is that ${MAKE} is not set in the situation.

So change ${MAKE} to ${MAKE-make} to resolve the issue.

Signed-off-by: Qinghua Jin <qhjin_dev@163.com>