### PR TITLE
Add --enable-jemalloc argument to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
       - gcc-multilib
       - libssl-dev
       - llvm-dev
+      - libjemalloc1
+      - libjemalloc-dev
 
 before_install: ./.travis/prepare.sh
 
@@ -33,6 +35,7 @@ env:
   - KERNEL=3.4.110
   - KERNEL=3.2.76
   - KERNEL=2.6.32.70
+  - OPTS="--enable-jemalloc"
 
 script: ./.travis/build.sh $OPTS
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -257,6 +257,10 @@ Here is an example:
       `% mkdir _gcc && (cd _gcc && ../configure CC=gcc)`  
       `% mkdir _clang && (cd _clang && ../configure CC=clang)`
 
+To use jemalloc as the memory allocator for OVSDB Server, add
+--enable-jemalloc, which links OVSDB Server with jemalloc (the library
+must be installed on the system). For the rationale about this flag
+refer to DESIGN.md.
 
 Building the Sources
 --------------------

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,20 @@ AC_SYS_LARGEFILE
 LT_INIT([disable-shared])
 m4_pattern_forbid([LT_INIT]) dnl Make autoconf fail if libtool is missing.
 
+AC_ARG_ENABLE([jemalloc],
+    [AS_HELP_STRING([--enable-jemalloc], [use jemalloc as the memory manager
+    instead of GLibC] @@)],
+    [enable_jemalloc=${enableval}],
+    [enable_jemalloc=no])
+
+AS_IF([test "x$enable_jemalloc" != xno],
+    [
+    AC_SEARCH_LIBS([malloc], [jemalloc],
+        [AM_CONDITIONAL(USE_JEMALLOC, true)],
+        [AM_CONDITIONAL(USE_JEMALLOC, false)])
+    ],
+    [AM_CONDITIONAL(USE_JEMALLOC, false)])
+
 # The following explanation may help to understand the use of the
 # version number fields: current, revision, and age.
 #

--- a/ovsdb/automake.mk
+++ b/ovsdb/automake.mk
@@ -66,6 +66,10 @@ MAN_ROOTS += ovsdb/ovsdb-client.1.in
 sbin_PROGRAMS += ovsdb/ovsdb-server
 ovsdb_ovsdb_server_SOURCES = ovsdb/ovsdb-server.c
 ovsdb_ovsdb_server_LDADD = ovsdb/libovsdb.la lib/libopenvswitch.la
+if USE_JEMALLOC
+ovsdb_ovsdb_server_LDADD += -ljemalloc
+endif
+
 # ovsdb-server.1
 man_MANS += ovsdb/ovsdb-server.1
 DISTCLEANFILES += ovsdb/ovsdb-server.1


### PR DESCRIPTION
During our tests with OVSDB we found out that memory allocation is
used intensively by the server, so we thought that using a different
memory allocator could increase the performance. We tried jemalloc
and the performance gain was between 20% and 40%.

This patch would allow anyone to enable jemalloc on their systems
in case you want to try out this memory allocator.

The patch adds the --enable-jemalloc flag to link ovsdb-server with jemalloc
instead of the default memory allocator. This can improve the OVSDB
Server performance under certains loads.

Signed-off-by: Esteban Rodriguez Betancourt <estebarb@hpe.com>