### PR TITLE
install.md: Suggest jemalloc memory allocator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
       - gcc-multilib
       - libssl-dev
       - llvm-dev
+      - libjemalloc1
+      - libjemalloc-dev
 
 before_install: ./.travis/prepare.sh
 
@@ -30,6 +32,7 @@ env:
   - KERNEL=3.14.60
   - KERNEL=3.12.53
   - KERNEL=3.10.96
+  - TESTSUITE=1 LIBS=-ljemalloc
 
 script: ./.travis/build.sh $OPTS
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -247,6 +247,13 @@ Here is an example:
       `% mkdir _gcc && (cd _gcc && ../configure CC=gcc)`
       `% mkdir _clang && (cd _clang && ../configure CC=clang)`
 
+Under certains loads the ovsdb-server and other components perform
+better when using the jemalloc memory allocator, instead of the GLibC
+memory allocator.
+
+If you wish to link with jemalloc add it to LIBS:
+
+      `% ./configure LIBS=-ljemalloc`
 
 Building the Sources
 --------------------


### PR DESCRIPTION
Change installing documentation to suggest to use
jemalloc memory allocator.

This memory allocator showed great performance gains
when used at ovsdb-server and other components.

Signed-off-by: Esteban Rodriguez Betancourt <estebarb@hpe.com>