### PR TITLE
Fix race condition between networking and openvswitch-switch

### DIFF
--- a/debian/ifupdown.sh
+++ b/debian/ifupdown.sh
@@ -33,6 +33,16 @@ if /etc/init.d/openvswitch-switch status > /dev/null 2>&1; then :; else
     /etc/init.d/openvswitch-switch start
 fi
 
+i=0; while [ $i -lt 10 ] ; do
+  if ovs_vsctl show > /dev/null ; then
+    break
+  else
+    echo "Waiting 3 seconds for working ovs-vsctl"
+    sleep 3
+    i=$((i+1))
+  fi
+done
+
 if [ "${MODE}" = "start" ]; then
     eval OVS_EXTRA=\"${IF_OVS_EXTRA}\"
 


### PR DESCRIPTION
Networking upstart service checks if openvsiwtch-switch service
is running (and starts it if it's not running) via
debian/ifupdown.sh hook. But service may be in 'start/pre-start'
state in which it's loading kmod and not yet able to connect to
the database. Which leads to failures in interfaces configuration.

In order to fix this, ifupdown.sh script should wait until
ovs-vsctl is fully functional (able to connectto DB) before trying
to add any records to the database.