### PR TITLE
smap,shash: add numeric and flexible sort

### DIFF
--- a/lib/shash.h
+++ b/lib/shash.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2010, 2011, 2016 Nicira, Inc.
+ * Copyright (C) 2016 Hewlett Packard Enterprise Development LP
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +72,9 @@ void *shash_find_and_delete(struct shash *, const char *);
 void *shash_find_and_delete_assert(struct shash *, const char *);
 struct shash_node *shash_first(const struct shash *);
 const struct shash_node **shash_sort(const struct shash *);
+const struct shash_node **shash_sort_numeric(const struct shash *);
+const struct shash_node **shash_sort_with_compar(const struct shash *,
+                                        int (*)(const void *, const void *));
 bool shash_equal_keys(const struct shash *, const struct shash *);
 struct shash_node *shash_random_node(struct shash *);
 

--- a/lib/smap.h
+++ b/lib/smap.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2012, 2014, 2015, 2016 Nicira, Inc.
+ * Copyright (C) 2016 Hewlett Packard Enterprise Development LP
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +94,9 @@ size_t smap_count(const struct smap *);
 
 void smap_clone(struct smap *dst, const struct smap *src);
 const struct smap_node **smap_sort(const struct smap *);
+const struct smap_node **smap_sort_numeric(const struct smap *);
+const struct smap_node **smap_sort_with_compar(const struct smap *,
+                                        int (*)(const void *, const void *));
 
 void smap_from_json(struct smap *, const struct json *);
 struct json *smap_to_json(const struct smap *);


### PR DESCRIPTION
The default implementation of shash_sort and smap_sort provide only
lexigraphic sorting. This patch allows both a numeric sort and a flexible
version where the caller provides a comparison function
("compar" being the name used in other standard functions e.g. qsort(3))

Change-Id: I12fd3f8eef3f627fc1482bda47ba8b2329123121
Signed-off-by: Kevin Worth kevin.worth@hpe.com
