### PR TITLE
Added port name printing to ovs-docker

### DIFF
--- a/utilities/ovs-docker
+++ b/utilities/ovs-docker
@@ -123,6 +123,8 @@ add_port () {
     ID=`uuidgen | sed 's/-//g'`
     PORTNAME="${ID:0:13}"
     ip link add "${PORTNAME}_l" type veth peer name "${PORTNAME}_c"
+    # Printing port name back for future flow rule installation
+    echo "{$PORTNAME}"
 
     # Add one end of veth to OVS bridge.
     if ovs_vsctl --may-exist add-port "$BRIDGE" "${PORTNAME}_l" \


### PR DESCRIPTION
Print out $PORTNAME to help future flow rule installation. Otherwise you need to keep track of the port-container mapping.
