### PR TITLE
ovsdb: Fix OVSDB disconnect replication bug

### DIFF
--- a/ovsdb/ovsdb-server.c
+++ b/ovsdb/ovsdb-server.c
@@ -351,7 +351,7 @@ main(int argc, char *argv[])
     sset_destroy(&remotes);
     sset_destroy(&db_filenames);
     unixctl_server_destroy(unixctl);
-    disconnect_remote_server();
+    destroy_remote_server();
 
     if (run_process && process_exited(run_process)) {
         int status = process_status(run_process);

--- a/ovsdb/replication.c
+++ b/ovsdb/replication.c
@@ -141,6 +141,14 @@ void
 disconnect_remote_server(void)
 {
     jsonrpc_close(rpc);
+    sset_clear(&monitored_tables);
+    sset_clear(&tables_blacklist);
+}
+
+void
+destroy_remote_server(void)
+{
+    jsonrpc_close(rpc);
     sset_destroy(&monitored_tables);
     sset_destroy(&tables_blacklist);
 
@@ -448,15 +456,13 @@ process_notification(struct json *table_updates, struct ovsdb *database)
         error = ovsdb_txn_commit(txn, false);
         if (error) {
             ovsdb_error_assert(error);
-            sset_clear(&monitored_tables);
+            disconnect_remote_server();
         }
     } else {
         ovsdb_txn_abort(txn);
         ovsdb_error_assert(error);
-        sset_clear(&monitored_tables);
+        disconnect_remote_server();
     }
-
-    ovsdb_error_destroy(error);
 }
 
 static struct ovsdb_error *
@@ -495,6 +501,9 @@ process_table_update(struct json *table_update, const char *table_name,
             } else {
                 error = execute_update(txn, node->name, table, new);
             }
+        }
+        if (error) {
+            break;
         }
     }
     return error;

--- a/ovsdb/replication.h
+++ b/ovsdb/replication.h
@@ -34,6 +34,7 @@ void replication_run(struct shash *dbs);
 void set_remote_ovsdb_server(const char *remote_server);
 void set_tables_blacklist(const char *blacklist);
 void disconnect_remote_server(void);
+void destroy_remote_server(void);
 const struct db *find_db(const struct shash *all_dbs, const char *db_name);
 void replication_usage(void);
 


### PR DESCRIPTION
Currently disconnecting from the replicator server means closing the jsonrpc
connection and destroying the monitored table names and blacklisted table
names.

This patch makes a distition between disconnecting from the remote server,
applicable when the replication incurs in an error, and destroying the
remote server info, applicable when ovsdb-server exits gracefully.

Signed-off-by: Mario Cabrera <mario.cabrera@hpe.com>