### PR TITLE
travis: Fix flake8 failures from flake8 3.0.

### DIFF
--- a/.travis/linux-prepare.sh
+++ b/.travis/linux-prepare.sh
@@ -2,4 +2,4 @@
 
 git clone git://git.kernel.org/pub/scm/devel/sparse/chrisl/sparse.git
 cd sparse && make && make install && cd ..
-pip install --disable-pip-version-check --user six flake8 hacking
+pip install --disable-pip-version-check --user six "flake8<3.0" hacking

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -127,11 +127,13 @@ installing the following to obtain better warnings:
 
   - clang, version 3.4 or later
 
-  - “flake8”, along with the “hacking” flake8 plugin (for Python code).
-    The automatic flake8 check that runs against Python code has some
-    warnings enabled that come from the "hacking" flake8 plugin.  If it's
-    not installed, the warnings just won't occur until it's run on a system
-    with "hacking" installed.
+  - “flake8”, version 2.X, along with the “hacking” flake8 plugin (for Python
+    code).  The automatic flake8 check that runs against Python code has some
+    warnings enabled that come from the "hacking" flake8 plugin.  If it's not
+    installed, the warnings just won't occur until it's run on a system with
+    "hacking" installed.  Note that there are problems with flake8 3.0 and the
+    “hacking” plugin.  To ensure you get flake8 2.X, you can use
+    “pip install ‘flake8<3.0’”.
 
 Also, you may find the ovs-dev script found in utilities/ovs-dev.py useful.
 


### PR DESCRIPTION
The "hacking" plugin for flake8 is not currently compatible with flake8
3.0.  Ensure that we install flake8 2.x on travis-ci.  Also update the
docs to indicate this incompatibility.

Signed-off-by: Russell Bryant <russell@ovn.org>