### PR TITLE
Strip quotes in SYSTEM_VERSION from os-release

### DIFF
--- a/utilities/ovs-ctl.in
+++ b/utilities/ovs-ctl.in
@@ -523,8 +523,8 @@ set_defaults () {
         SYSTEM_TYPE=`cat $type_file`
         SYSTEM_VERSION=`cat $version_file`
     elif test -e "@sysconfdir@/os-release"; then
-        SYSTEM_TYPE=`awk -F= '/^ID=/{print $2}' @sysconfdir@/os-release`
-        SYSTEM_VERSION=`awk -F= '/^VERSION_ID=/{print $2}' @sysconfdir@/os-release`
+        SYSTEM_TYPE=`. "@sysconfdir@/os-release" && echo "$ID"`
+        SYSTEM_VERSION=`. "@sysconfdir@/os-release" && echo "$VERSION_ID"`
     elif (lsb_release --id) >/dev/null 2>&1; then
         SYSTEM_TYPE=`lsb_release --id -s`
         system_release=`lsb_release --release -s`


### PR DESCRIPTION
The /etc/os-release file on Ubuntu 14.04 contains:
VERSION_ID="14.04"

Currently this leads to an error starting openvswitch-switch saying:
ovs-vsctl: ""14.04"": quoted string may not include unescaped "

This causes ovs-vswitchd to not get started. With this fix the quotes
will be removed from VERSION_ID and SYSTEM_VERSION will be set to the
correct value of just 14.04.

Signed-off-by: Matt Mulsow <mamulsow@us.ibm.com>