### PR TITLE
delete possible quotes in SYSTEM_TYPE/SYSTEM_VERSION in file utilites…

### DIFF
--- a/utilities/ovs-ctl.in
+++ b/utilities/ovs-ctl.in
@@ -534,6 +534,10 @@ set_defaults () {
         SYSTEM_TYPE=unknown
         SYSTEM_VERSION=unknown
     fi
+    temp=${SYSTEM_TYPE#\"}
+    SYSTEM_TYPE=${temp%\"}
+    temp={$SYSTEM_VERSION#\"}
+    SYSTEM_VERSION=${temp%\"}
 }
 
 usage () {


### PR DESCRIPTION
utiles/ovs-ctl.in

In some distribution, the variable may be put in quotes in file
/etc/os-release. This caused the error when runing at function set_system_ids() in utiles/ovs-ctl.