### PR TITLE
netdev-dpdk:fixing private size req in mempool_create

### DIFF
--- a/lib/netdev-dpdk.c
+++ b/lib/netdev-dpdk.c
@@ -350,7 +350,7 @@ dpdk_mp_get(int socket_id, int mtu) OVS_REQUIRES(dpdk_mutex)
 
         dmp->mp = rte_mempool_create(mp_name, mp_size, MBUF_SIZE(mtu),
                                      MP_CACHE_SZ,
-                                     sizeof(struct rte_pktmbuf_pool_private),
+                                     sizeof (struct dp_packet) - sizeof(struct rte_mbuf),
                                      rte_pktmbuf_pool_init, NULL,
                                      ovs_rte_pktmbuf_init, NULL,
                                      socket_id, 0);


### PR DESCRIPTION
rte_pktmbuf_pool_init will expect the packet to be of size rte_mbuf,
however ovs reserve extra area in buffer.

This extra area should be part of private area.
In the existing code, the private area is sized as  "rte_pktmbuf_pool_private", which is not being used anywhere.

For OVS, the private area reserve should be:
(dp_packet size - size of rte_mbuf)

Signed-off-by: Hemant Agrawal <hemant.agrawal@nxp.com>