### PR TITLE
Avoid segfault in sFlow when datapath input port for tunnel sample is unknown.

### DIFF
--- a/lib/sflow_agent.c
+++ b/lib/sflow_agent.c
@@ -128,12 +128,15 @@ void sfl_agent_tick(SFLAgent *agent, time_t now)
     SFLSampler *sm = agent->samplers;
     SFLPoller *pl = agent->pollers;
     agent->now = now;
-    /* receivers use ticks to flush send data */
-    for(; rcv != NULL; rcv = rcv->nxt) sfl_receiver_tick(rcv, now);
     /* samplers use ticks to decide when they are sampling too fast */
     for(; sm != NULL; sm = sm->nxt) sfl_sampler_tick(sm, now);
     /* pollers use ticks to decide when to ask for counters */
     for(; pl != NULL; pl = pl->nxt) sfl_poller_tick(pl, now);
+    /* receivers use ticks to flush send data.  By doing this
+     * step last we ensure that fresh counters polled during
+     * sfl_poller_tick() above will be flushed promptly.
+     */
+    for(; rcv != NULL; rcv = rcv->nxt) sfl_receiver_tick(rcv, now);
 }
 
 /*_________________---------------------------__________________

--- a/ofproto/ofproto-dpif-sflow.c
+++ b/ofproto/ofproto-dpif-sflow.c
@@ -1287,7 +1287,7 @@ dpif_sflow_received(struct dpif_sflow *ds, const struct dp_packet *packet,
     if (flow->tunnel.ip_dst) {
 	memset(&tnlInElem, 0, sizeof(tnlInElem));
 	tnlInElem.tag = SFLFLOW_EX_IPV4_TUNNEL_INGRESS;
-	tnlInProto = dpif_sflow_tunnel_proto(in_dsp->tunnel_type);
+	tnlInProto = in_dsp ? dpif_sflow_tunnel_proto(in_dsp->tunnel_type) : 0;
 	dpif_sflow_tunnel_v4(tnlInProto,
 			     &flow->tunnel,
 			     &tnlInElem.flowType.ipv4);


### PR DESCRIPTION
The crash is documented here:
http://openvswitch.org/pipermail/discuss/2016-August/022513.html

Signed-off-by: Neil McKee <neil.mckee@inmon.com>