### PR TITLE
Tutorial.md: Specify the type of interface.

### DIFF
--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -237,7 +237,7 @@ We need to add p1, p2, p3, and p4.  A shell "for" loop is one way to
 do it:
 
     for i in 1 2 3 4; do
-        ovs-vsctl add-port br0 p$i -- set Interface p$i ofport_request=$i
+        ovs-vsctl add-port br0 p$i -- set Interface p$i ofport_request=$i type=internal
 	      ovs-ofctl mod-port br0 p$i up
     done
 

--- a/tutorial/t-setup
+++ b/tutorial/t-setup
@@ -3,6 +3,6 @@
 ovs-vsctl add-br br0 -- set Bridge br0 fail-mode=secure
 
 for i in 1 2 3 4; do
-    ovs-vsctl add-port br0 p$i -- set Interface p$i ofport_request=$i
+    ovs-vsctl add-port br0 p$i -- set Interface p$i ofport_request=$i type=internal
     ovs-ofctl mod-port br0 p$i up
 done


### PR DESCRIPTION
When I tried to run the script of setup without specifying the type of interface, ovs-ofctl can't find the port just added.

like this:

``` bash
ovs-ofctl: br0: couldn't find port `p1'
ovs-ofctl: br0: couldn't find port `p2'
ovs-ofctl: br0: couldn't find port `p3'
ovs-ofctl: br0: couldn't find port `p4'
```

So I specified the type of interface to resolve the issue.

Signed-off-by: Yan Hao Chen coolking29@gmail.com
