### PR TITLE
Check for multiple tunnels before updating ipsec config

### DIFF
--- a/debian/ovs-monitor-ipsec
+++ b/debian/ovs-monitor-ipsec
@@ -355,7 +355,21 @@ class IPsec:
 
 def update_ipsec(ipsec, interfaces, new_interfaces):
     for name, vals in interfaces.iteritems():
-        if name not in new_interfaces:
+        del_if = True
+        if name in new_interfaces:
+            del_if = False
+        else:
+            # Check if there still is ANOTHER tunnel present! Multiple tunnels
+            # between two hosts can exist without issues when they share a PSK
+            # over different bridges and ports.
+            # So we need to be careful when removing policies without double
+            # checking as this could break other tunnels that should not be
+            # affected!
+            for new_name, new_vals in new_interfaces.iteritems():
+                if (vals["local_ip"] == new_vals["local_ip"]) and (vals["remote_ip"] == new_vals["remote_ip"]):
+                    del_if = False
+
+        if del_if:
             ipsec.del_entry(vals["local_ip"], vals["remote_ip"])
 
     for name, vals in new_interfaces.iteritems():


### PR DESCRIPTION
**First of all:**
I'm fully aware that ipsec support has been depricated in 2.6. Since we're still running on 2.4 and need an intermediate fix before the migration to 2.6 can be completed, we decided to write this patch and submit it to the community so that anyone can benefit from it.

**The issue we fixed:**
When updating ipsec config, we need to make sure the LAST tunnel between two hosts is being deleted before actually modifying the racoon, psk.txt etc. files. Failing to do this properly will cause other perfectly functional tunnels to break which is obviously not what we want to happen...

**A practical example:**

<pre>
$ ovs-vsctl show
0c7401c0-d716-450e-b8c4-79502495a68d
    Bridge "matProPro"
        fail_mode: secure
        Port "matProPro"
            Interface "matProPro"
                type: internal
        Port "0f2a3424d6b9-e"
            Interface "0f2a3424d6b9-e"
        Port "ipsec_gre_22890"
            Interface "ipsec_gre_22890"
                type: ipsec_gre
                options: {key="22890", psk="360e84a779e951be5a0b0705f3222b0600a991b3", remote_ip="10.129.5.16"}
        Port "0f2a3424d6b9-i"
            Interface "0f2a3424d6b9-i"
    Bridge "matTunPro"
        fail_mode: secure
        Port "05fa093607ea-i"
            Interface "05fa093607ea-i"
        Port "ipsec_gre_34169"
            Interface "ipsec_gre_34169"
                type: ipsec_gre
                options: {key="34169", psk="360e84a779e951be5a0b0705f3222b0600a991b3", remote_ip="10.129.5.16"}
        Port "matTunPro"
            Interface "matTunPro"
                type: internal
        Port "05fa093607ea-e"
            Interface "05fa093607ea-e"
    Bridge "mvJusPro"
        fail_mode: secure
        Port "ipsec_gre_82325"
            Interface "ipsec_gre_82325"
                type: ipsec_gre
                options: {key="82325", psk="29340a19a97a3ead33653380aa997242ce677a2c", remote_ip="128.167.23.88"}
        Port "mvJusPro"
            Interface "mvJusPro"
                type: internal
    ovs_version: "2.4.0"
</pre>


As you can see, there are two (2) tunnels to 10.129.5.16 that use **the same psk** `360e84a779e951be5a0b0705f3222b0600a991b3` but a different key (22890 and 34169).

Everything is fully operational: all traffic is flowing as it should.

Now, if you would delete **bridge** `matProPro` **or** port `ipsec_gre_22890` for whatever reason (cleanup, ...), **the result before this patch** would be that **both of these tunnels break**!

The reason for this is that the OVS ipsec monitor does not take the possibility of multiple tunnels between the same hosts into account.
Multiple ipsec tunnels between the same host **must** use the same PSK but should use a different key for traffic separation to the proper bridge.

The patch proposed here will take care of handling the multiple tunnel possibility and only clean up when the last tunnel between two hosts is being removed.
