### PR TITLE
python-six is required in the build process

### DIFF
--- a/rhel/openvswitch.spec.in
+++ b/rhel/openvswitch.spec.in
@@ -33,6 +33,7 @@ Release: 1
 Source: openvswitch-%{version}.tar.gz
 Buildroot: /tmp/openvswitch-rpm
 Requires: logrotate, python >= 2.7, python-six
+BuildRequires: python-six
 BuildRequires: openssl-devel
 BuildRequires: checkpolicy, selinux-policy-devel
 


### PR DESCRIPTION
the build error log is:

```
Traceback (most recent call last):
Traceback (most recent call last):
  File "./ovsdb/ovsdb-idlc.in", line 8, in <module>
    import ovs.json
  File "/root/rpmbuild/BUILD/openvswitch-2.6.1/python/ovs/json.py", line 21, in <module>
    import six
ImportError: No module named six
```

Signed-off-by: Jian Li <lijian@ooclab.com>