### PR TITLE
id-pool: Fix allocation overflow and the leak of the first id

### DIFF
--- a/lib/id-pool.c
+++ b/lib/id-pool.c
@@ -130,7 +130,7 @@ id_pool_alloc_id(struct id_pool *pool, uint32_t *id_)
 found_free_id:
     id_pool_add(pool, id);
 
-    if (id < pool->base + pool->n_ids) {
+    if (id <= pool->base + pool->n_ids) {
         pool->next_free_id = id + 1;
     } else {
         pool->next_free_id = pool->base;

--- a/lib/id-pool.c
+++ b/lib/id-pool.c
@@ -130,7 +130,7 @@ id_pool_alloc_id(struct id_pool *pool, uint32_t *id_)
 found_free_id:
     id_pool_add(pool, id);
 
-    if (id <= pool->base + pool->n_ids) {
+    if (id + 1 < pool->base + pool->n_ids) {
         pool->next_free_id = id + 1;
     } else {
         pool->next_free_id = pool->base;

--- a/lib/id-pool.c
+++ b/lib/id-pool.c
@@ -144,7 +144,7 @@ void
 id_pool_free_id(struct id_pool *pool, uint32_t id)
 {
     struct id_node *id_node;
-    if (id > pool->base && (id <= pool->base + pool->n_ids)) {
+    if (id >= pool->base && (id < pool->base + pool->n_ids)) {
         id_node = id_pool_find(pool, id);
         if (id_node) {
             hmap_remove(&pool->map, &id_node->node);


### PR DESCRIPTION
id_pool_alloc_id() could always allocate (pool->n_ids + 1) ids rather than pool->n_ids ids, it worked well while pool->n_ids = 0.