### PR TITLE
id-pool: Fix allocation overflow and the leak of the first ID.

### DIFF
--- a/lib/id-pool.c
+++ b/lib/id-pool.c
@@ -130,7 +130,7 @@ id_pool_alloc_id(struct id_pool *pool, uint32_t *id_)
 found_free_id:
     id_pool_add(pool, id);
 
-    if (id < pool->base + pool->n_ids) {
+    if (id + 1 < pool->base + pool->n_ids) {
         pool->next_free_id = id + 1;
     } else {
         pool->next_free_id = pool->base;
@@ -144,7 +144,7 @@ void
 id_pool_free_id(struct id_pool *pool, uint32_t id)
 {
     struct id_node *id_node;
-    if (id > pool->base && (id <= pool->base + pool->n_ids)) {
+    if (id >= pool->base && (id < pool->base + pool->n_ids)) {
         id_node = id_pool_find(pool, id);
         if (id_node) {
             hmap_remove(&pool->map, &id_node->node);


### PR DESCRIPTION
The range of IDs should be [base, base + n_ids), 
but `id_pool_alloc_id()` allocated the range of IDs is [base, base + n_ids].
And `id_pool_free_id()` cannot free the ID value base correctly.

Signed-off-by: Yangchao Zhou <zhouyates@gmail.com>