### PR TITLE
ovs-vsctl:fix assertion in ovs-vsctl list netflow bridge command

### DIFF
--- a/lib/db-ctl-base.c
+++ b/lib/db-ctl-base.c
@@ -346,6 +346,8 @@ get_row_by_id(struct ctl_context *ctx,
         if (uuid->n == 1) {
             final = ovsdb_idl_get_row_for_uuid(ctx->idl, table,
                                                &uuid->keys[0].uuid);
+        } else {
+            final = NULL;
         }
     }
     return final;


### PR DESCRIPTION
This fixes an assertion failure in command "ovs-vsctl list netflow br",if bridge br without any netflows.
$ovs-vsctl list netflow br103
ovs-vsctl: lib/ovsdb-idl.c:2407: assertion column_idx < class->n_columns failed in ovsdb_idl_read()
Aborted

Get_row_by_id() shoudle return NULL if not find by ovsdb_idl_get_row_for_uuid().

Signed-off-by: Zhipeng Lu <lu.zhipeng@zte.com.cn>