### PR TITLE
lacp: enable bond slave immediately after lacp attach

### DIFF
--- a/lib/lacp.c
+++ b/lib/lacp.c
@@ -536,6 +536,7 @@ lacp_run(struct lacp *lacp, lacp_send_pdu *send_pdu) OVS_EXCLUDED(mutex)
 
     if (lacp->update) {
         lacp_update_attached(lacp);
+        seq_change(connectivity_seq_get());
     }
 
     HMAP_FOR_EACH (slave, node, &lacp->slaves) {


### PR DESCRIPTION
There is a long interval (5~20 seconds) between lacp slave attach
and bond slave enable. During the interval, ovs drop all received
packets from that slave because bond_check_admissibility() check
fails. The root cause is that connectivity_seq is not changed
after lacp update and lacp status is not populated into port->may_enable
by port_run() immediately.

Signed-off-by: Huanle Han <hanxueluo@gmail.com>