### PR TITLE
tests: fix sparse error on test-ovn.c

### DIFF
--- a/tests/test-ovn.c
+++ b/tests/test-ovn.c
@@ -202,7 +202,7 @@ create_addr_sets(struct shash *addr_sets)
     static const char *const addrs3[] = {
         "00:00:00:00:00:01", "00:00:00:00:00:02", "00:00:00:00:00:03",
     };
-    static const char *const addrs4[] = { 0 };
+    static const char *const addrs4[] = { NULL };
 
     expr_addr_sets_add(addr_sets, "set1", addrs1, 3);
     expr_addr_sets_add(addr_sets, "set2", addrs2, 3);


### PR DESCRIPTION
Commit d5c70d4bcc344ae10a644b83f1790a0235871efc fixed the MSVC issue
however, introduced a sparse error:
"tests/test-ovn.c:205:43: warning: Using plain integer as NULL pointer"

Use 'NULL' instead of '0'.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
---
This PR is only to trigger the Travis CI