### PR TITLE
rhel: Fix build rpm error on CentOS 6.8 & 6.9 (& newest kernel 3.19.0)

### DIFF
--- a/datapath/linux/compat/flow_dissector.c
+++ b/datapath/linux/compat/flow_dissector.c
@@ -46,6 +46,7 @@ static void iph_to_flow_copy_addrs(struct flow_keys *flow, const struct iphdr *i
 	memcpy(&flow->src, &iph->saddr, sizeof(flow->src) + sizeof(flow->dst));
 }
 
+#if RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6,8)
 static __be32 skb_flow_get_ports(const struct sk_buff *skb, int thoff, u8 ip_proto)
 {
 	int poff = proto_ports_offset(ip_proto);
@@ -191,6 +192,7 @@ ipv6:
 
 	return true;
 }
+#endif
 
 static u32 hashrnd __read_mostly;
 static __always_inline void __flow_hash_secret_init(void)

--- a/datapath/linux/compat/include/linux/if_vlan.h
+++ b/datapath/linux/compat/include/linux/if_vlan.h
@@ -5,6 +5,13 @@
 #include <linux/version.h>
 #include_next <linux/if_vlan.h>
 
+#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0)) || \
+     (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(6,8)))
+#define vlan_tx_tag_present skb_vlan_tag_present
+#define vlan_tx_tag_get skb_vlan_tag_get
+#define vlan_tx_tag_get_id skb_vlan_tag_get_id
+#endif
+
 #ifndef HAVE_VLAN_INSERT_TAG_SET_PROTO
 /*
  * The behavior of __vlan_put_tag()/vlan_insert_tag_set_proto() has changed

--- a/datapath/linux/compat/include/net/flow_keys.h
+++ b/datapath/linux/compat/include/net/flow_keys.h
@@ -3,7 +3,8 @@
 
 #include <linux/version.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,0)
+#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,0)) || \
+     (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(6,8)))
 #include_next <net/flow_keys.h>
 #else
 struct flow_keys {


### PR DESCRIPTION
Add support for RHEL6.8 & 6.9 (& newest kernel 3.19.0) which uses an old version of kernel with some new features backported.