### PR TITLE
Dpdk merge Sept 22 2017

### DIFF
--- a/.travis/linux-build.sh
+++ b/.travis/linux-build.sh
@@ -81,7 +81,7 @@ fi
 
 if [ "$DPDK" ]; then
     if [ -z "$DPDK_VER" ]; then
-        DPDK_VER="17.05.1"
+        DPDK_VER="17.05.2"
     fi
     install_dpdk $DPDK_VER
     if [ "$CC" = "clang" ]; then

--- a/Documentation/faq/releases.rst
+++ b/Documentation/faq/releases.rst
@@ -161,8 +161,8 @@ Q: What DPDK version does each Open vSwitch release work with?
     2.4.x        2.0
     2.5.x        2.2
     2.6.x        16.07.2
-    2.7.x        16.11.2
-    2.8.x        17.05.1
+    2.7.x        16.11.3
+    2.8.x        17.05.2
     ============ =======
 
 Q: I get an error like this when I configure Open vSwitch:

--- a/Documentation/intro/install/dpdk.rst
+++ b/Documentation/intro/install/dpdk.rst
@@ -40,7 +40,7 @@ Build requirements
 In addition to the requirements described in :doc:`general`, building Open
 vSwitch with DPDK will require the following:
 
-- DPDK 17.05.1
+- DPDK 17.05.2
 
 - A `DPDK supported NIC`_
 
@@ -69,9 +69,9 @@ Install DPDK
 #. Download the `DPDK sources`_, extract the file and set ``DPDK_DIR``::
 
        $ cd /usr/src/
-       $ wget http://fast.dpdk.org/rel/dpdk-17.05.1.tar.xz
-       $ tar xf dpdk-17.05.1.tar.xz
-       $ export DPDK_DIR=/usr/src/dpdk-stable-17.05.1
+       $ wget http://fast.dpdk.org/rel/dpdk-17.05.2.tar.xz
+       $ tar xf dpdk-17.05.2.tar.xz
+       $ export DPDK_DIR=/usr/src/dpdk-stable-17.05.2
        $ cd $DPDK_DIR
 
 #. (Optional) Configure DPDK as a shared library

--- a/Documentation/topics/dpdk/vhost-user.rst
+++ b/Documentation/topics/dpdk/vhost-user.rst
@@ -292,9 +292,9 @@ To begin, instantiate a guest as described in :ref:`dpdk-vhost-user` or
 DPDK sources to VM and build DPDK::
 
     $ cd /root/dpdk/
-    $ wget http://fast.dpdk.org/rel/dpdk-17.05.1.tar.xz
-    $ tar xf dpdk-17.05.1.tar.xz
-    $ export DPDK_DIR=/root/dpdk/dpdk-stable-17.05.1
+    $ wget http://fast.dpdk.org/rel/dpdk-17.05.2.tar.xz
+    $ tar xf dpdk-17.05.2.tar.xz
+    $ export DPDK_DIR=/root/dpdk/dpdk-stable-17.05.2
     $ export DPDK_TARGET=x86_64-native-linuxapp-gcc
     $ export DPDK_BUILD=$DPDK_DIR/$DPDK_TARGET
     $ cd $DPDK_DIR
@@ -378,7 +378,7 @@ Sample XML
         </disk>
         <disk type='dir' device='disk'>
           <driver name='qemu' type='fat'/>
-          <source dir='/usr/src/dpdk-stable-17.05.1'/>
+          <source dir='/usr/src/dpdk-stable-17.05.2'/>
           <target dev='vdb' bus='virtio'/>
           <readonly/>
         </disk>

--- a/lib/conntrack.c
+++ b/lib/conntrack.c
@@ -1141,17 +1141,16 @@ conntrack_execute(struct conntrack *ct, struct dp_packet_batch *pkt_batch,
                   long long now)
 {
 
-    struct dp_packet **pkts = pkt_batch->packets;
-    size_t cnt = pkt_batch->count;
+    struct dp_packet *packet;
     struct conn_lookup_ctx ctx;
 
-    for (size_t i = 0; i < cnt; i++) {
-        if (!conn_key_extract(ct, pkts[i], dl_type, &ctx, zone)) {
-            pkts[i]->md.ct_state = CS_INVALID;
-            write_ct_md(pkts[i], zone, NULL, NULL, NULL);
+    DP_PACKET_BATCH_FOR_EACH (packet, pkt_batch) {
+        if (!conn_key_extract(ct, packet, dl_type, &ctx, zone)) {
+            packet->md.ct_state = CS_INVALID;
+            write_ct_md(packet, zone, NULL, NULL, NULL);
             continue;
         }
-        process_one(ct, pkts[i], &ctx, zone, force, commit,
+        process_one(ct, packet, &ctx, zone, force, commit,
                     now, setmark, setlabel, nat_action_info, helper);
     }
 

--- a/lib/dp-packet.c
+++ b/lib/dp-packet.c
@@ -103,7 +103,6 @@ dp_packet_init_dpdk(struct dp_packet *b, size_t allocated)
 {
     dp_packet_set_allocated(b, allocated);
     b->source = DPBUF_DPDK;
-    b->packet_type = htonl(PT_ETH);
 }
 
 /* Initializes 'b' as an empty dp_packet with an initial capacity of 'size'

--- a/lib/dp-packet.h
+++ b/lib/dp-packet.h
@@ -805,12 +805,13 @@ dp_packet_delete_batch(struct dp_packet_batch *batch, bool may_steal)
 }
 
 static inline void
-dp_packet_batch_init_cutlen(struct dp_packet_batch *batch)
+dp_packet_batch_init_packet_fields(struct dp_packet_batch *batch)
 {
     struct dp_packet *packet;
 
     DP_PACKET_BATCH_FOR_EACH (packet, batch) {
         dp_packet_reset_cutlen(packet);
+        packet->packet_type = htonl(PT_ETH);
     }
 }
 

--- a/lib/dpif-netdev.c
+++ b/lib/dpif-netdev.c
@@ -5124,9 +5124,8 @@ dp_netdev_input__(struct dp_netdev_pmd_thread *pmd,
                   struct dp_packet_batch *packets,
                   bool md_is_valid, odp_port_t port_no)
 {
-    int cnt = packets->count;
 #if !defined(__CHECKER__) && !defined(_WIN32)
-    const size_t PKT_ARRAY_SIZE = cnt;
+    const size_t PKT_ARRAY_SIZE = dp_packet_batch_size(packets);
 #else
     /* Sparse or MSVC doesn't like variable length array. */
     enum { PKT_ARRAY_SIZE = NETDEV_MAX_BURST };

--- a/lib/dpif-netdev.c
+++ b/lib/dpif-netdev.c
@@ -3933,7 +3933,9 @@ pmd_free_cached_ports(struct dp_netdev_pmd_thread *pmd)
 }
 
 /* Copies ports from 'pmd->tx_ports' (shared with the main thread) to
- * 'pmd->port_cache' (thread local) */
+ * thread-local copies. Copy to 'pmd->tnl_port_cache' if it is a tunnel
+ * device, otherwise to 'pmd->send_port_cache' if the port has at least
+ * one txq. */
 static void
 pmd_load_cached_ports(struct dp_netdev_pmd_thread *pmd)
     OVS_REQUIRES(pmd->port_mutex)

--- a/lib/netdev-dpdk.c
+++ b/lib/netdev-dpdk.c
@@ -2942,14 +2942,14 @@ netdev_dpdk_ring_send(struct netdev *netdev, int qid,
                       bool concurrent_txq)
 {
     struct netdev_dpdk *dev = netdev_dpdk_cast(netdev);
-    unsigned i;
+    struct dp_packet *packet;
 
     /* When using 'dpdkr' and sending to a DPDK ring, we want to ensure that
      * the rss hash field is clear. This is because the same mbuf may be
      * modified by the consumer of the ring and return into the datapath
      * without recalculating the RSS hash. */
-    for (i = 0; i < batch->count; i++) {
-        dp_packet_mbuf_rss_flag_reset(batch->packets[i]);
+    DP_PACKET_BATCH_FOR_EACH (packet, batch) {
+        dp_packet_mbuf_rss_flag_reset(packet);
     }
 
     netdev_dpdk_send__(dev, qid, batch, may_steal, concurrent_txq);

--- a/lib/netdev-dpdk.c
+++ b/lib/netdev-dpdk.c
@@ -1669,8 +1669,9 @@ netdev_dpdk_vhost_rxq_recv(struct netdev_rxq *rxq,
                                          nb_rx, dropped);
     rte_spinlock_unlock(&dev->stats_lock);
 
-    dp_packet_batch_init_cutlen(batch);
-    batch->count = (int) nb_rx;
+    batch->count = nb_rx;
+    dp_packet_batch_init_packet_fields(batch);
+
     return 0;
 }
 
@@ -1709,8 +1710,8 @@ netdev_dpdk_rxq_recv(struct netdev_rxq *rxq, struct dp_packet_batch *batch)
         rte_spinlock_unlock(&dev->stats_lock);
     }
 
-    dp_packet_batch_init_cutlen(batch);
     batch->count = nb_rx;
+    dp_packet_batch_init_packet_fields(batch);
 
     return 0;
 }


### PR DESCRIPTION
Backports to 2.8:

docs: Use DPDK 17.05.2 release

netdev-dpdk: reset packet_type for reused dp_packets.
