### PR TITLE
Fix a typo in the bridge name in the howto guide

### DIFF
--- a/Documentation/howto/userspace-tunneling.rst
+++ b/Documentation/howto/userspace-tunneling.rst
@@ -92,7 +92,7 @@ Perform the folowing configuration on `host1`:
 #. Add a port to this bridge. If using tap ports, first boot a VM and then add
    the port to the bridge::
 
-       $ ovs-vsctl add-port br0 tap0
+       $ ovs-vsctl add-port br-int tap0
 
    If using DPDK vhost-user ports, add the port and then boot the VM
    accordingly, using ``vm_port0`` as the interface name::


### PR DESCRIPTION
This commit fixes potential unintended mistake in howto guide of userspace tunneling. 
Fixes a problem in commit message in #208 