### PR TITLE
Portability fix. Change #include order

### DIFF
--- a/lib/conntrack.c
+++ b/lib/conntrack.c
@@ -17,10 +17,10 @@
 #include <config.h>
 #include <ctype.h>
 #include <errno.h>
+#include <sys/types.h>
 #include <netinet/in.h>
 #include <netinet/icmp6.h>
 #include <string.h>
-#include <sys/types.h>
 
 #include "bitmap.h"
 #include "conntrack.h"


### PR DESCRIPTION
This file doesn't compile on FreeBSD nor OS X because icmp6.h needs definitions from sys/types.h.

On Linux icmp6.h includes sys/types.h itself but it's not a good idea to assume that everyone does. Besides, I think it's much more clear to put it before the netinet stuff so that more "fundamental" definitions are included first.

