### PR TITLE
ovn-sbctl: remove incorrect manpage options for --bootstrap-ca-cert and --peer-ca-cert

### DIFF
--- a/ovn/utilities/ovn-sbctl.8.in
+++ b/ovn/utilities/ovn-sbctl.8.in
@@ -100,8 +100,6 @@ These options control the format of output from the \fBlist\fR and
 .
 .SS "Public Key Infrastructure Options"
 .so lib/ssl.man
-.so lib/ssl-bootstrap.man
-.so lib/ssl-peer-ca-cert.man
 .
 .SH COMMANDS
 The commands implemented by \fBovn\-sbctl\fR are described in the


### PR DESCRIPTION
These options are not implemented by ovn-sbctl.

Signed-off-by: Dan Williams <dcbw@redhat.com>

@shettyg 