### PR TITLE
rpm: depend on /bin/sed instead of /usr/bin/sed for compatibility

### DIFF
--- a/rhel/openvswitch-fedora.spec.in
+++ b/rhel/openvswitch-fedora.spec.in
@@ -94,7 +94,7 @@ Requires: openssl hostname iproute module-init-tools
 
 Requires(post): /usr/bin/getent
 Requires(post): /usr/sbin/useradd
-Requires(post): /usr/bin/sed
+Requires(post): /bin/sed
 %if %{with dpdk}
 Requires(post): /usr/sbin/usermod
 Requires(post): /usr/sbin/groupadd


### PR DESCRIPTION
The sed package in RHEL/CentOS 7 only provides /bin/sed and not
/usr/bin/sed, but later versions (including Fedora) provide both.