### PR TITLE
ovn-sbctl: add support for --bootstrap-ca-cert

### DIFF
--- a/manpages.mk
+++ b/manpages.mk
@@ -12,12 +12,14 @@ ovn/utilities/ovn-sbctl.8: \
 	ovn/utilities/ovn-sbctl.8.in \
 	lib/common.man \
 	lib/db-ctl-base.man \
+	lib/ssl-bootstrap.man \
 	lib/ssl.man \
 	lib/table.man \
 	lib/vlog.man
 ovn/utilities/ovn-sbctl.8.in:
 lib/common.man:
 lib/db-ctl-base.man:
+lib/ssl-bootstrap.man:
 lib/ssl.man:
 lib/table.man:
 lib/vlog.man:

--- a/ovn/utilities/ovn-nbctl.c
+++ b/ovn/utilities/ovn-nbctl.c
@@ -490,7 +490,7 @@ Options:\n\
 Other options:\n\
   -h, --help                  display this help message\n\
   -V, --version               display version information\n");
-    stream_usage("database", true, true, false);
+    stream_usage("database", true, true, true);
     exit(EXIT_SUCCESS);
 }
 

--- a/ovn/utilities/ovn-sbctl.8.in
+++ b/ovn/utilities/ovn-sbctl.8.in
@@ -112,6 +112,7 @@ These options control the format of output from the \fBlist\fR and
 .so lib/table.man
 .
 .SS "Public Key Infrastructure Options"
+.so lib/ssl-bootstrap.man
 .so lib/ssl.man
 .
 .SH COMMANDS

--- a/ovn/utilities/ovn-sbctl.c
+++ b/ovn/utilities/ovn-sbctl.c
@@ -170,6 +170,7 @@ parse_options(int argc, char *argv[], struct shash *local_options)
         OPT_LOCAL,
         OPT_COMMANDS,
         OPT_OPTIONS,
+        OPT_BOOTSTRAP_CA_CERT,
         VLOG_OPTION_ENUMS,
         TABLE_OPTION_ENUMS,
         SSL_OPTION_ENUMS,
@@ -188,6 +189,7 @@ parse_options(int argc, char *argv[], struct shash *local_options)
         {"version", no_argument, NULL, 'V'},
         VLOG_LONG_OPTIONS,
         STREAM_SSL_LONG_OPTIONS,
+        {"bootstrap-ca-cert", required_argument, NULL, OPT_BOOTSTRAP_CA_CERT},
         TABLE_LONG_OPTIONS,
         {NULL, 0, NULL, 0},
     };
@@ -275,6 +277,10 @@ parse_options(int argc, char *argv[], struct shash *local_options)
         TABLE_OPTION_HANDLERS(&table_style)
         STREAM_SSL_OPTION_HANDLERS
 
+        case OPT_BOOTSTRAP_CA_CERT:
+            stream_ssl_set_ca_cert_file(optarg, true);
+            break;
+
         case '?':
             exit(EXIT_FAILURE);
 
@@ -355,7 +361,7 @@ Options:\n\
 Other options:\n\
   -h, --help                  display this help message\n\
   -V, --version               display version information\n");
-    stream_usage("database", true, true, false);
+    stream_usage("database", true, true, true);
     exit(EXIT_SUCCESS);
 }
 


### PR DESCRIPTION
Brings it in-line with ovn-nbctl.

@LorenzoBianconi @jsitnicki @orgcandman @shettyg @rajatchopra