### PR TITLE
python/ovs: zerofill event id in vlog and remove field padding

### DIFF
--- a/python/ovs/vlog.py
+++ b/python/ovs/vlog.py
@@ -102,7 +102,7 @@ class Vlog(object):
             elif "m" in m:
                 tmp = self._format_field(tmp, m, message)
             elif "N" in m:
-                tmp = self._format_field(tmp, m, str(msg_num))
+                tmp = self._format_field(tmp, m, str(msg_num), True)
             elif "n" in m:
                 tmp = re.sub(m, "\n", tmp)
             elif "p" in m:
@@ -128,17 +128,18 @@ class Vlog(object):
                 tmp = self._format_field(tmp, m, subprogram)
         return tmp.strip()
 
-    def _format_field(self, tmp, match, replace):
+    def _format_field(self, tmp, match, replace, zerofill=False):
         formatting = re.compile("^%(0)?([1-9])?")
         matches = formatting.match(match)
-        # Do we need to apply padding?
-        if not matches.group(1) and replace != "":
-            replace = replace.center(len(replace) + 2)
         # Does the field have a minimum width
         if matches.group(2):
             min_width = int(matches.group(2))
             if len(replace) < min_width:
-                replace = replace.center(min_width)
+                if zerofill:
+                    for i in range(len(replace), min_width):
+                        replace = "0" + replace;
+                else:
+                    replace = replace.center(min_width)
         return re.sub(match, replace, tmp)
 
     def _format_time(self, tmp):


### PR DESCRIPTION
Make the logging format consitent with OVS the rest of OVS logs.

Currently, the log output generated by `vlog` has padding for each field.
Additionally, the event identifier, e.g. `1`, is not padded with zeros:

```
2018-03-27T23:30:54.090Z |  1  | ovn-docker-overlay-driver | INFO | ovn-docker-overlay-driver: test
```

This change removes the field padding and adds zerofill to event
identtifiers:

```
2018-03-27T23:46:58.762Z|00001|ovn-docker-overlay-driver|INFO|ovn-docker-overlay-driver: test
```

Signed-off-by: Paul Greenberg <greenpau@outlook.com>