### PR TITLE
vlog: exit with error if explicitly specified logfile cannot be opened

### DIFF
--- a/include/openvswitch/vlog.h
+++ b/include/openvswitch/vlog.h
@@ -251,9 +251,14 @@ void vlog_rate_limit(const struct vlog_module *, enum vlog_level,
         case 'v':                               \
             vlog_set_verbosity(optarg);         \
             break;                              \
-        case OPT_LOG_FILE:                      \
-            vlog_set_log_file(optarg);          \
+        case OPT_LOG_FILE: {                    \
+            int err = vlog_set_log_file(optarg);\
+            /* exit if logfile explicitly given \
+             * but cannot be opened. */         \
+            if (err != 0 && optarg)             \
+                exit(EXIT_FAILURE);             \
             break;                              \
+        }                                       \
         case OPT_SYSLOG_IMPL:                   \
             vlog_set_syslog_method(optarg);     \
             break;                              \


### PR DESCRIPTION
It seems like if the user wanted a specific logfile but that request
cannot be fulfilled, OVS/OVN shouldn't just continue as if nothing
really happened (besides logging a warning).

Signed-off-by: Dan Williams <dcbw@redhat.com>

@shettyg @rajatchopra @fleitner @putnopvut