### PR TITLE
Removed calls to API deprecated in openssl 1.1

### DIFF
--- a/lib/stream-ssl.c
+++ b/lib/stream-ssl.c
@@ -947,12 +947,14 @@ do_ssl_init(void)
 {
     SSL_METHOD *method;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined (LIBRESSL_VERSION_NUMBER)
 #ifdef _WIN32
     /* The following call is needed if we "#include <openssl/applink.c>". */
     CRYPTO_malloc_init();
 #endif
     SSL_library_init();
     SSL_load_error_strings();
+#endif
 
     if (!RAND_status()) {
         /* We occasionally see OpenSSL fail to seed its random number generator


### PR DESCRIPTION
In openssl 1.1, there is no need to initialize the library.  It is automatically done when first used.  This patch allows to compile openvswitch against openssl 1.1.0 with deprecated API disabled.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>