### PR TITLE
Return error code for Rule insert and delete

### DIFF
--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -4444,7 +4444,7 @@ rule_construct(struct rule *rule_)
     return 0;
 }
 
-static void
+static enum ofperr
 rule_insert(struct rule *rule_, struct rule *old_rule_, bool forward_counts)
     OVS_REQUIRES(ofproto_mutex)
 {
@@ -4474,6 +4474,8 @@ rule_insert(struct rule *rule_, struct rule *old_rule_, bool forward_counts)
         ovs_mutex_unlock(&rule->stats_mutex);
         ovs_mutex_unlock(&old_rule->stats_mutex);
     }
+
+    return 0;
 }
 
 static void

--- a/ofproto/ofproto-provider.h
+++ b/ofproto/ofproto-provider.h
@@ -1297,10 +1297,11 @@ struct ofproto_class {
     struct rule *(*rule_alloc)(void);
     enum ofperr (*rule_construct)(struct rule *rule)
         /* OVS_REQUIRES(ofproto_mutex) */;
-    void (*rule_insert)(struct rule *rule, struct rule *old_rule,
-                        bool forward_counts)
+    enum ofperr (*rule_insert)(struct rule *rule, struct rule *old_rule,
+                                                    bool forward_counts)
         /* OVS_REQUIRES(ofproto_mutex) */;
-    void (*rule_delete)(struct rule *rule) /* OVS_REQUIRES(ofproto_mutex) */;
+    enum ofperr (*rule_delete)(struct rule *rule)
+        /* OVS_REQUIRES(ofproto_mutex) */;
     void (*rule_destruct)(struct rule *rule);
     void (*rule_dealloc)(struct rule *rule);
 


### PR DESCRIPTION
Currently, rule_insert() and rule_delete() ofproto provider APIs donot
have return values.

There are some possible scenarios where rule insertions and deletions can
fail at runtime even though the static checks during rule_construct() had
passed previously.

Some possible scenarios for failure of rule insertions and deletions:

**) Rule insertions can fail dynamically in Hybrid mode (both Openflow and
Normal switch functioning coexist) where the CAM space could get suddenly
filled up by Normal switch functioning and Openflow gets devoid of
available space.

**) Some deployments could have separate independent layers for HW rule
insertions/deletions and application layer to interact with OVS. HW layer
could face any dynamic issue during rule handling which application could
not have predicted/captured in rule-construction phase.

This patch is the first step to introduce error reporting for rule
insertions/deletions from Client back to OVS.
