### PR TITLE
Fix DHCP classless static route for non-classfull masks (i.e. any oth…

### DIFF
--- a/ovn/lib/actions.c
+++ b/ovn/lib/actions.c
@@ -1667,11 +1667,7 @@ encode_put_dhcpv4_option(const struct ovnact_gen_option *o,
             if (c[i].masked) {
                 plen = (uint8_t) ip_count_cidr_bits(c[i].mask.ipv4);
             }
-            if (plen % 8) {
-                opt_header[1] += (1 + plen / 8 + 1 + sizeof(ovs_be32));
-            } else {
-                opt_header[1] += (1 + plen / 8 + sizeof(ovs_be32));
-            }
+            opt_header[1] += (1 + DIV_ROUND_UP(plen, 8) + sizeof(ovs_be32));
         }
 
         /* Copied from RFC 3442. Please refer to this RFC for the format of
@@ -1696,11 +1692,7 @@ encode_put_dhcpv4_option(const struct ovnact_gen_option *o,
                 plen = ip_count_cidr_bits(c[i].mask.ipv4);
             }
             ofpbuf_put(ofpacts, &plen, 1);
-            if (plen % 8) {
-                ofpbuf_put(ofpacts, &c[i].value.ipv4, plen / 8 + 1);
-            } else {
-                ofpbuf_put(ofpacts, &c[i].value.ipv4, plen / 8);
-            }
+            ofpbuf_put(ofpacts, &c[i].value.ipv4, DIV_ROUND_UP(plen, 8));
             ofpbuf_put(ofpacts, &c[i + 1].value.ipv4,
                        sizeof(ovs_be32));
         }

--- a/ovn/lib/actions.c
+++ b/ovn/lib/actions.c
@@ -1667,7 +1667,11 @@ encode_put_dhcpv4_option(const struct ovnact_gen_option *o,
             if (c[i].masked) {
                 plen = (uint8_t) ip_count_cidr_bits(c[i].mask.ipv4);
             }
-            opt_header[1] += (1 + (plen / 8) + sizeof(ovs_be32)) ;
+            if (plen % 8) {
+                opt_header[1] += (1 + plen / 8 + 1 + sizeof(ovs_be32));
+            } else {
+                opt_header[1] += (1 + plen / 8 + sizeof(ovs_be32));
+            }
         }
 
         /* Copied from RFC 3442. Please refer to this RFC for the format of
@@ -1692,7 +1696,11 @@ encode_put_dhcpv4_option(const struct ovnact_gen_option *o,
                 plen = ip_count_cidr_bits(c[i].mask.ipv4);
             }
             ofpbuf_put(ofpacts, &plen, 1);
-            ofpbuf_put(ofpacts, &c[i].value.ipv4, plen / 8);
+            if (plen % 8) {
+                ofpbuf_put(ofpacts, &c[i].value.ipv4, plen / 8 + 1);
+            } else {
+                ofpbuf_put(ofpacts, &c[i].value.ipv4, plen / 8);
+            }
             ofpbuf_put(ofpacts, &c[i + 1].value.ipv4,
                        sizeof(ovs_be32));
         }


### PR DESCRIPTION
…er than /0, /8, /16, /24, /32)

When trying to determine how many bytes of ip address needs to be included in classless static route option,
we should take into consideration the following.
To get the correct amount of bytes we need to take number of network bits in the mask and divide it by 8.
But if the mask has a remainder when divided, we need to not ignore this and add 1 byte to the to the length of the option.

Signed-off-by: Rostyslav Fridman <rostyslav_fridman@epam.com>