### PR TITLE
Correct ifupdown.sh to bring up bonded links properly.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -189,6 +189,7 @@ Justin Pettit                      jpettit@ovn.org
 Kaige Fu                           fukaige@huawei.com
 Keith Amidon                       keith@nicira.com
 Ken Ajiro                          ajiro@mxw.nes.nec.co.jp
+Ken Sanislo                        ken@intherack.com
 Kenneth Duda                       kduda@arista.com
 Kentaro Ebisawa                    ebiken.g@gmail.com
 Kevin Lo                           kevlo@FreeBSD.org

--- a/debian/ifupdown.sh
+++ b/debian/ifupdown.sh
@@ -67,7 +67,7 @@ if [ "${MODE}" = "start" ]; then
                 ip link set "${IFACE}" up
                 for slave in ${IF_OVS_BONDS}
                 do
-                    ip link set "${IFACE}" up
+                    ip link set "${slave}" up
                 done
                 ;;
         OVSPatchPort)


### PR DESCRIPTION
It seems that line 70 needs to be operating on the $slave variable created in the for loop at :68.

Bonded interfaces fail to bring up their links with the current version, this will makes them work correctly.

Signed-off-by: Ken Sanislo <ken@intherack.com>