### PR TITLE
rhel: move ovsdb socket to ovsdb-server.socket unit

### DIFF
--- a/Documentation/ref/ovsdb.7.rst
+++ b/Documentation/ref/ovsdb.7.rst
@@ -423,6 +423,11 @@ punix:<file>
     On Windows, listens on a local named pipe, creating a named pipe
     <file> to mimic the behavior of a Unix domain socket.
 
+pfd:<fd>
+    On Unix-like systems, accepts connections on a socket already listening
+    socket. This is useful with service managers that are able to manage
+    sockets such as systemd.
+
 All IP-based connection methods accept IPv4 and IPv6 addresses.  To specify an
 IPv6 address, wrap it in square brackets, e.g.  ``ssl:[::1]:6640``.  Passive
 IP-based connection methods by default listen for IPv4 connections only; use

--- a/lib/stream-provider.h
+++ b/lib/stream-provider.h
@@ -192,6 +192,7 @@ extern const struct pstream_class ptcp_pstream_class;
 #ifndef _WIN32
 extern const struct stream_class unix_stream_class;
 extern const struct pstream_class punix_pstream_class;
+extern const struct pstream_class pfd_pstream_class;
 #else
 extern const struct stream_class windows_stream_class;
 extern const struct pstream_class pwindows_pstream_class;

--- a/lib/stream-unix.c
+++ b/lib/stream-unix.c
@@ -136,3 +136,32 @@ const struct pstream_class punix_pstream_class = {
     NULL,
 };
 
+static int
+pfd_open(const char *name, char *suffix,
+             struct pstream **pstreamp, uint8_t dscp OVS_UNUSED)
+{
+    int fd, error;
+    char *end;
+
+    fd = strtol(suffix, &end, 10);
+    if (*end != '\0' || fd < 0 || fd >= INT_MAX) {
+        VLOG_ERR("%s: bad file descriptor number", suffix);
+        return ERANGE;
+    }
+
+    error = set_nonblocking(fd);
+    if (error)
+        return error;
+
+    return new_fd_pstream(xstrdup(name), fd,
+                          punix_accept, NULL, pstreamp);
+}
+
+const struct pstream_class pfd_pstream_class = {
+    "pfd",
+    false,
+    pfd_open,
+    NULL,
+    NULL,
+    NULL,
+};

--- a/lib/stream.c
+++ b/lib/stream.c
@@ -68,6 +68,7 @@ static const struct pstream_class *pstream_classes[] = {
     &ptcp_pstream_class,
 #ifndef _WIN32
     &punix_pstream_class,
+    &pfd_pstream_class,
 #else
     &pwindows_pstream_class,
 #endif

--- a/rhel/automake.mk
+++ b/rhel/automake.mk
@@ -30,6 +30,7 @@ EXTRA_DIST += \
 	rhel/usr_lib_udev_rules.d_91-vfio.rules \
 	rhel/usr_lib_systemd_system_openvswitch.service \
 	rhel/usr_lib_systemd_system_ovsdb-server.service \
+	rhel/usr_lib_systemd_system_ovsdb-server.socket \
 	rhel/usr_lib_systemd_system_ovs-vswitchd.service.in \
 	rhel/usr_lib_systemd_system_ovs-delete-transient-ports.service \
 	rhel/usr_lib_systemd_system_ovn-controller.service \

--- a/rhel/openvswitch-fedora.spec.in
+++ b/rhel/openvswitch-fedora.spec.in
@@ -259,11 +259,13 @@ install -p -D -m 0644 rhel/usr_lib_udev_rules.d_91-vfio.rules \
 install -p -D -m 0644 \
         rhel/usr_share_openvswitch_scripts_systemd_sysconfig.template \
         $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/openvswitch
-for service in openvswitch ovsdb-server ovs-vswitchd ovs-delete-transient-ports \
-                ovn-controller ovn-controller-vtep ovn-northd; do
+for unit in openvswitch.service ovsdb-server.service ovsdb-server.socket \
+                ovs-vswitchd.service ovs-delete-transient-ports.service \
+                ovn-controller.service ovn-controller-vtep.service \
+                ovn-northd.service; do
         install -p -D -m 0644 \
-                        rhel/usr_lib_systemd_system_${service}.service \
-                        $RPM_BUILD_ROOT%{_unitdir}/${service}.service
+                        rhel/usr_lib_systemd_system_${unit} \
+                        $RPM_BUILD_ROOT%{_unitdir}/${unit}
 done
 install -m 0755 rhel/etc_init.d_openvswitch \
         $RPM_BUILD_ROOT%{_datadir}/openvswitch/scripts/openvswitch.init
@@ -542,6 +544,7 @@ fi
 %config(noreplace) %{_sysconfdir}/logrotate.d/openvswitch
 %{_unitdir}/openvswitch.service
 %{_unitdir}/ovsdb-server.service
+%{_unitdir}/ovsdb-server.socket
 %{_unitdir}/ovs-vswitchd.service
 %{_unitdir}/ovs-delete-transient-ports.service
 %{_datadir}/openvswitch/scripts/openvswitch.init

--- a/rhel/usr_lib_systemd_system_ovs-delete-transient-ports.service
+++ b/rhel/usr_lib_systemd_system_ovs-delete-transient-ports.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Open vSwitch Delete Transient Ports
-After=ovsdb-server.service
+After=ovsdb-server.socket
 Before=ovs-vswitchd.service
-AssertPathExists=/var/run/openvswitch/db.sock
 
 [Service]
 Type=oneshot

--- a/rhel/usr_lib_systemd_system_ovs-vswitchd.service.in
+++ b/rhel/usr_lib_systemd_system_ovs-vswitchd.service.in
@@ -1,10 +1,9 @@
 [Unit]
 Description=Open vSwitch Forwarding Unit
-After=ovsdb-server.service network-pre.target systemd-udev-settle.service
+After=ovsdb-server.socket network-pre.target systemd-udev-settle.service
 Before=network.target network.service
-Requires=ovsdb-server.service
-ReloadPropagatedFrom=ovsdb-server.service
-AssertPathIsReadWrite=/var/run/openvswitch/db.sock
+Requires=ovsdb-server.socket
+ReloadPropagatedFrom=ovsdb-server.socket
 PartOf=openvswitch.service
 
 [Service]

--- a/rhel/usr_lib_systemd_system_ovsdb-server.service
+++ b/rhel/usr_lib_systemd_system_ovsdb-server.service
@@ -23,3 +23,4 @@ ExecReload=/usr/share/openvswitch/scripts/ovs-ctl --no-ovs-vswitchd \
            --no-monitor restart $OPTIONS
 RuntimeDirectory=openvswitch
 RuntimeDirectoryMode=0755
+RuntimeDirectoryPreserve=no

--- a/rhel/usr_lib_systemd_system_ovsdb-server.socket
+++ b/rhel/usr_lib_systemd_system_ovsdb-server.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=Open vSwitch Database Socket
+Before=ovsdb-server.service
+
+[Socket]
+ListenStream=/var/run/openvswitch/db.sock
+Service=ovsdb-server.service
+
+[Install]
+WantedBy=sockets.target

--- a/utilities/ovs-ctl.in
+++ b/utilities/ovs-ctl.in
@@ -132,7 +132,12 @@ do_start_ovsdb () {
             set "$@" --no-self-confinement
         fi
         set "$@" -vconsole:emer -vsyslog:err -vfile:info
-        set "$@" --remote=punix:"$DB_SOCK"
+        if test X"$LISTEN_FDNAMES" = X"ovsdb-server.socket"; then
+            unset LISTEN_FDS LISTEN_FDNAMES LISTEN_PID
+            set "$@" --remote=pfd:3
+        else
+            set "$@" --remote=punix:"$DB_SOCK"
+        fi
         set "$@" --private-key=db:Open_vSwitch,SSL,private_key
         set "$@" --certificate=db:Open_vSwitch,SSL,certificate
         set "$@" --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert


### PR DESCRIPTION
When ovsdb-server.service is restarted, there's a time window during which clients aren't able to connect to the socket. To cope with this, systemd is able to manage the sockets and pass it to the services. This patch set makes use of the facility.