### PR TITLE
Documentation: cosmetic fix for example flows

### DIFF
--- a/Documentation/topics/tracing.rst
+++ b/Documentation/topics/tracing.rst
@@ -39,7 +39,7 @@ Packet Tracing
 --------------
 
 In order to understand the tool, let's use the following flows as an
-example:
+example::
 
     table=3,ip,tcp,tcp_dst=80,action=output:2
     table=2,ip,tcp,tcp_dst=22,action=output:1


### PR DESCRIPTION
Just a cosmetic change on the list of 4 flows at the beginning of the page.
The problem was that with a big enough browser, the first two lines got merged on a single line.

Putting those 4 lines into a block avoid the line merging.
That said, this style is used for code. I let you judge if you find it ok.