### PR TITLE
netdev-linux: respect configure result when including net/if_packet.h

### DIFF
--- a/lib/netdev-linux.c
+++ b/lib/netdev-linux.c
@@ -39,7 +39,9 @@
 #include <netpacket/packet.h>
 #include <net/if.h>
 #include <net/if_arp.h>
+#ifdef HAVE_IF_PACKET
 #include <net/if_packet.h>
+#endif
 #include <net/route.h>
 #include <poll.h>
 #include <stdlib.h>


### PR DESCRIPTION
The configure script already tests whether net/if_packet.h is
available. Respect the test result to fix build issues with musl
libc.