### PR TITLE
append Dockerfile filename to build command

### DIFF
--- a/Documentation/tutorials/faucet.rst
+++ b/Documentation/tutorials/faucet.rst
@@ -130,7 +130,7 @@ between one and the other.
 
 2. Build a docker container image::
 
-     $ docker build -t faucet/faucet .
+     $ docker build -t faucet/faucet -f Dockerfile.faucet .
 
    This will take a few minutes.
 


### PR DESCRIPTION
Faucet latest version (1.8.23) repository doesn't contain Dockerfile (it has multiple Dockerfiles), so docker build failed. I added Dockerfile.faucet as Dockerfile to the command.