### PR TITLE
python-c-ext: Fix memory leak in Parser_finish

### DIFF
--- a/python/ovs/_json.c
+++ b/python/ovs/_json.c
@@ -170,6 +170,7 @@ Parser_finish(json_ParserObject * self)
     json = json_parser_finish(self->_parser);
     self->_parser = NULL;
     obj = json_to_python(json);
+    json_destroy(json);
     return obj;
 }
 


### PR DESCRIPTION
The memory returned by json_parser_finish needs to be freed by the caller.

Signed-off-by: Eric Lapointe <elapointe@corsa.com>
---
This fix can easily be tested using the following script in the python shell and looking at the memory usage with 'top':
```
import ovs.json
input = '{"key": "value"}'
while True:
    p = ovs.json.Parser()
    input = input[p.feed(input):]
    json = p.finish()
```