### PR TITLE
python-ovsdb: Changes to fetch list type values from ovsdb

### DIFF
--- a/python/ovs/db/data.py
+++ b/python/ovs/db/data.py
@@ -493,6 +493,11 @@ class Datum(object):
                 if dk is not None and dv is not None:
                     value[dk] = dv
             return value
+        elif self.type.is_list():
+            values = list()
+            for k in self.values.keys():
+                values.append(k)
+            return values
         else:
             s = set()
             for k in self.values:

--- a/python/ovs/db/types.py
+++ b/python/ovs/db/types.py
@@ -500,6 +500,9 @@ class Type(object):
     def is_map(self):
         return self.value is not None
 
+    def is_list(self):
+        return self.key is not None and self.value is None
+
     def is_smap(self):
         return (self.is_map()
                 and self.key.type == StringType


### PR DESCRIPTION
There is a problem when loading ovs ports list with python-ovsdb lib. "Datum.to_python()" returns None.
For example,

\# ovs-vsctl get <br_name> port
[108beebd-3089-425a-a55d-aedaeddb8107, 92cb0e47-8c7d-4dfc-8480-410eea3411a3, a0cd6f8d-5cbc-433f-b52a-f7671ecba71b, ad9afb13-8246-4a06-bf04-0fca0093012c]

Signed-off-by: Nobody Void <black0027@hotmail.com>