### PR TITLE
Add --span to mirror all ports on bridge

### DIFF
--- a/utilities/ovs-tcpdump.8.in
+++ b/utilities/ovs-tcpdump.8.in
@@ -42,6 +42,9 @@ be dumped.
 The name of the interface which should be the destination of the mirrored
 packets. The default is miINTERFACE
 .
+.IP "\fB\-\-span\fR"
+If specified, mirror all ports (optional).
+.
 .SH "SEE ALSO"
 .
 .BR ovs\-appctl (8),

--- a/utilities/ovs-tcpdump.in
+++ b/utilities/ovs-tcpdump.in
@@ -111,6 +111,7 @@ The following options are available:
    -i, --interface            Open vSwitch interface to mirror and tcpdump
    --mirror-to                The name for the mirror port to use (optional)
                               Default 'miINTERFACE'
+   --span                     If specified, mirror all ports (optional)
 """ % {'prog': sys.argv[0]})
     sys.exit(0)
 
@@ -312,13 +313,13 @@ class OVSDB(object):
         self._txn = None
         return result
 
-    def bridge_mirror(self, intf_name, mirror_intf_name, br_name):
+    def bridge_mirror(self, intf_name, mirror_intf_name, br_name, mirror_select_all = False):
 
         txn = self._start_txn()
         mirror = txn.insert(self.get_table('Mirror'))
         mirror.name = 'm_%s' % intf_name
 
-        mirror.select_all = False
+        mirror.select_all = mirror_select_all
 
         mirrored_port = self._find_row_by_name('Port', intf_name)
 
@@ -404,6 +405,9 @@ def main():
             mirror_interface = nxt
             skip_next = True
             continue
+        elif  cur in ['--span']:
+            mirror_select_all = True
+            continue
         tcpdargs.append(cur)
 
     if interface is None:
@@ -445,7 +449,8 @@ def main():
     try:
         ovsdb.make_port(mirror_interface, ovsdb.port_bridge(interface))
         ovsdb.bridge_mirror(interface, mirror_interface,
-                            ovsdb.port_bridge(interface))
+                            ovsdb.port_bridge(interface),
+                            mirror_select_all)
     except OVSDBException as oe:
         print("ERROR: Unable to properly setup the mirror: %s." % str(oe))
         try:


### PR DESCRIPTION
When the command line option, --span, is specified, mirror.select_all is set True.