### PR TITLE
docs: Fix typo in faq/vlan.rst

### DIFF
--- a/Documentation/faq/vlan.rst
+++ b/Documentation/faq/vlan.rst
@@ -191,7 +191,7 @@ Q: Can I configure an IP address on a VLAN?
         $ ovs-vsctl add-port br0 vlan9 tag=9 \
             -- set interface vlan9 type=internal
         $ ip addr add 192.168.0.7/24 dev vlan9
-        $ ip link set vlan0 up
+        $ ip link set vlan9 up
 
     See also the following question.
 
@@ -203,7 +203,7 @@ Q: I configured one IP address on VLAN 0 and another on VLAN 9, like this::
     $ ip link set br0 up
     $ ovs-vsctl add-port br0 vlan9 tag=9 -- set interface vlan9 type=internal
     $ ip addr add 192.168.0.9/24 dev vlan9
-    $ ip link set vlan0 up
+    $ ip link set vlan9 up
 
 but other hosts that are only on VLAN 0 can reach the IP address configured on
 VLAN 9.  What's going on?


### PR DESCRIPTION
The VLAN 9 configuration example should be using `vlan9` instead of `vlan0`.

Signed-off-by: Charles Alva charlesalva@gmail.com