### PR TITLE
rhel: Fix rpmbuild fails for rhel 

### DIFF
--- a/rhel/openvswitch.spec.in
+++ b/rhel/openvswitch.spec.in
@@ -263,6 +263,7 @@ exit 0
 /usr/share/openvswitch/scripts/ovs-save
 /usr/share/openvswitch/scripts/ovs-vtep
 /usr/share/openvswitch/scripts/sysconfig.template
+/usr/share/openvswitch/scripts/ovs-monitor-ipsec
 /usr/share/openvswitch/vswitch.ovsschema
 /usr/share/openvswitch/vtep.ovsschema
 %doc NOTICE README.rst NEWS rhel/README.RHEL.rst


### PR DESCRIPTION
This patch fixes the rpm build fail for rhel. The error is:
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/openvswitch-2.10.0-1.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/share/openvswitch/scripts/ovs-monitor-ipsec

Signed-off-by: ZhiPeng LU <luzhipeng@uniudc.com>