### PR TITLE
Fix OpenFlow v1.3.4 Conf test failures: 430.500, 430.510

### DIFF
--- a/lib/meta-flow.c
+++ b/lib/meta-flow.c
@@ -3503,7 +3503,7 @@ mf_vl_mff_nx_pull_entry(struct ofpbuf *b, const struct vl_mff_map *vl_mff_map,
                         const struct mf_field **field, union mf_value *value,
                         union mf_value *mask, uint64_t *tlv_bitmap)
 {
-    enum ofperr error = nx_pull_entry(b, vl_mff_map, field, value, mask);
+    enum ofperr error = nx_pull_entry(b, vl_mff_map, field, value, mask, true);
     if (error) {
         return error;
     }

--- a/lib/nx-match.h
+++ b/lib/nx-match.h
@@ -82,7 +82,7 @@ int oxm_put_field_array(struct ofpbuf *, const struct field_array *,
  * ID followed by a value and possibly a mask). */
 enum ofperr nx_pull_entry(struct ofpbuf *, const struct vl_mff_map *,
                           const struct mf_field **, union mf_value *value,
-                          union mf_value *mask);
+                          union mf_value *mask, bool is_action);
 enum ofperr nx_pull_header(struct ofpbuf *, const struct vl_mff_map *,
                            const struct mf_field **, bool *masked);
 void nxm_put_entry_raw(struct ofpbuf *, enum mf_field_id field,

--- a/tests/ofp-actions.at
+++ b/tests/ofp-actions.at
@@ -746,6 +746,20 @@ dnl Check the ONF extension form of "copy_field".
 # actions=move:NXM_OF_IN_PORT[]->NXM_OF_VLAN_TCI[]
 ffff 0020 4f4e4600 0c80 0000 0010 0000 0000 0000 00000002 00000802 00000000
 
+dnl Check OpenFlow v1.3.4 Conformance Test: 430.500.
+# bad OpenFlow13 actions: OFPBAC_BAD_SET_TYPE
+& ofp_actions|WARN|bad action at offset 0 (OFPBAC_BAD_SET_TYPE):
+& 00000000  00 19 00 08 80 00 fe 00-00 00 00 10 00 00 00 01
+& 00000010  00 00 00 00 00 00 00 00-
+0019 0008 8000fe00 000000100000 000100000000 00000000
+
+dnl Check OpenFlow v1.3.4 Conformance Test: 430.510.
+# bad OpenFlow13 actions: OFPBAC_BAD_SET_LEN
+& ofp_actions|WARN|bad action at offset 0 (OFPBAC_BAD_SET_LEN):
+& 00000000  00 19 00 10 80 00 08 07-00 01 02 03 04 05 00 00
+& 00000010  00 00 00 10 00 00 00 01-
+0019 0010 80000807 000102030405 000000000010 00000001
+
 ])
 sed '/^[[#&]]/d' < test-data > input.txt
 sed -n 's/^# //p; /^$/p' < test-data > expout


### PR DESCRIPTION
This commit adds additional verification to nx_pull_header__()
in lib/nx-match.c to distinguish between bad match and bad action
header conditions and return the appropriate error type/code.

Signed-off-by: Prashanth Iyengar <prashanth_iyengar@alliedtelesis.com>
Reviewed-by: Tony van der Peet <tony.vanderpeet@alliedtelesis.co.nz>
Reviewed-by: Rahul Gupta <Rahul_Gupta@alliedtelesis.com>