### PR TITLE
Update Python package requirements

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -82,7 +82,8 @@ setup_args = dict(
     ext_modules=[setuptools.Extension("ovs._json", sources=["ovs/_json.c"],
                                       libraries=['openvswitch'])],
     cmdclass={'build_ext': try_build_ext},
-    install_requires=['sortedcontainers'],
+    install_requires=['sortedcontainers',
+                      'pywin32>=1.0;platform_system=="Windows"'],
 )
 
 try:


### PR DESCRIPTION
The Python ovs package relies on pywin32 for Windows support.
For this reason, pywin32 should be included in the requirements
list.