### PR TITLE
ifupdown.sh: Add missing "--may-exist" option

### DIFF
--- a/debian/ifupdown.sh
+++ b/debian/ifupdown.sh
@@ -60,7 +60,7 @@ if [ "${MODE}" = "start" ]; then
                 ip link set "${IFACE}" up
                 ;;
         OVSBond)
-                ovs_vsctl -- --fake-iface add-bond "${IF_OVS_BRIDGE}"\
+                ovs_vsctl -- --fake-iface --may-exist add-bond "${IF_OVS_BRIDGE}"\
                     "${IFACE}" ${IF_OVS_BONDS} ${IF_OVS_OPTIONS} \
                     ${OVS_EXTRA+-- $OVS_EXTRA}
 


### PR DESCRIPTION
The ifupdown.sh script passes the --may-exist option
to ovs-vsctl invocations in order for it to exit without failing
if the device to be added already exists. This holds true for
all cases of adding objects to ovs-vswitchd except for when
configuring a bond interface.

This patch adds the --may-exist option to the missing
statement, which suppresses the logging of such errors in
syslog.

Additionally, running the unpatched version of this script when
the bond interface already exists appears to break
networking with some versions of ifupdown found in debian 
testing (0.8.35), where the service won't start up properly
because of the aforementioned errors.

Signed-off-by: George Diamantopoulos <georgediam@gmail.com>