### PR TITLE
Add new 'passthrough' nat_type

### DIFF
--- a/ovn/northd/ovn-northd.8.xml
+++ b/ovn/northd/ovn-northd.8.xml
@@ -2386,6 +2386,15 @@ nd_ns {
         </p>
         <p>
           For each configuration in the OVN Northbound database, that asks
+          NOT to change the source IP address of a packet with address
+          <var>A</var> is going to destination <var>B</var> or NOT to change
+          the source IP address of a packet thath belongs to network <var>A</var>
+          that is going to destination <var>B</var>, a priority-100 flow with
+          a match of <code>ip &amp;&amp; ip4.src == <var>A</var> &amp;&amp;
+          ip4.dst == <var>B</var></code> and an action of <code>next;</code>.
+        </p>
+        <p>
+          For each configuration in the OVN Northbound database, that asks
           to change the source IP address of a packet from an IP address of
           <var>A</var> or to change the source IP address of a packet that
           belongs to network <var>A</var> to <var>B</var>, a flow matches

--- a/ovn/ovn-nb.ovsschema
+++ b/ovn/ovn-nb.ovsschema
@@ -1,7 +1,7 @@
 {
     "name": "OVN_Northbound",
-    "version": "5.16.0",
-    "cksum": "923459061 23095",
+    "version": "5.16.1",
+    "cksum": "2460088216 23171",
     "tables": {
         "NB_Global": {
             "columns": {
@@ -343,6 +343,7 @@
                 "type": {"type": {"key": {"type": "string",
                                            "enum": ["set", ["dnat",
                                                              "snat",
+                                                             "passthrough",
                                                              "dnat_and_snat"
                                                                ]]}}},
                 "external_ids": {

--- a/ovn/ovn-nb.xml
+++ b/ovn/ovn-nb.xml
@@ -2030,6 +2030,14 @@
           <ref column="external_ip"/>.
         </li>
         <li>
+          When <ref column="type"/> is <code>passthrough</code>, IP packets
+          with their source IP address that either matches the IP address
+          in <ref column="logical_ip"/> or is in the network provided by
+          <ref column="logical_ip"/> is not SNATed to destination IP address
+          in <ref column="external_ip"/> or destination network provided by
+          <ref column="external_ip"/> and is allowed to pass-through.
+        </li>
+        <li>
           When <ref column="type"/> is <code>dnat_and_snat</code>, the
           externally visible IP address <ref column="external_ip"/> is
           DNATted to the IP address <ref column="logical_ip"/> in the

--- a/tests/ovn-nbctl.at
+++ b/tests/ovn-nbctl.at
@@ -404,7 +404,7 @@ dnl ---------------------------------------------------------------------
 OVN_NBCTL_TEST([ovn_nbctl_nats], [NATs], [
 AT_CHECK([ovn-nbctl lr-add lr0])
 AT_CHECK([ovn-nbctl lr-nat-add lr0 snatt 30.0.0.2 192.168.1.2], [1], [],
-[ovn-nbctl: snatt: type must be one of "dnat", "snat" and "dnat_and_snat".
+[ovn-nbctl: snatt: type must be one of "dnat", "snat", "passthrough" and "dnat_and_snat".
 ])
 AT_CHECK([ovn-nbctl lr-nat-add lr0 snat 30.0.0.2a 192.168.1.2], [1], [],
 [ovn-nbctl: 30.0.0.2a: should be an IPv4 address.


### PR DESCRIPTION
'passthrough' expects source network in 'logical_ip' column and destination network in 'external_ip' column.
For the traffic that goes from source to destination 'passthrough' disables NAT by adding a priority-100 flow with a match of 'ip && ip4.src == A && ip4.dst == B' and an action of 'next;'.

Signed-off-by: Rostyslav Fridman <rostyslav_fridman@epam.com>