### PR TITLE
only revalidate the flows whose actions are not drop.

### DIFF
--- a/ofproto/ofproto-dpif-upcall.c
+++ b/ofproto/ofproto-dpif-upcall.c
@@ -2681,9 +2681,15 @@ revalidate(struct revalidator *revalidator)
             }
             if (kill_them_all || (used && used < now - max_idle)) {
                 result = UKEY_DELETE;
-            } else {
+            } else if (f->actions_len > 0) {
+                /*Only revalidate the flows whose actions are not drop. 
+                 *The drop flows might be invalidate that will cause some 
+                 *flows with drop action were deleted wrongly.
+                 *For drop flows, they will be deleted when timeout occurs.*/
                 result = revalidate_ukey(udpif, ukey, &f->stats, &odp_actions,
-                                         reval_seq, &recircs);
+                        reval_seq, &recircs);
+            } else {
+                result = UKEY_KEEP;
             }
             ukey->dump_seq = dump_seq;
 


### PR DESCRIPTION
1) phenomena
     Briefly, the flows with drop actions are deleted by revalidator thread wrongly which causes all the 
     upcoming packets need to go to userspace and which wastes lots of time.



    a) For example, there is a machine (A) running ovs with one configured one vxlan interface with 
      tunnel value 123,  then all the vxlan traffics destinate to this machine(A) will be dealt with the ovs.

     b)  Although the ovs in machine A only configured with one vxlan tunnel (123), all the vxlan traffics 
        regardless the tunnel value is 123 or not, will be delivered to the vswitchd to do the slow path if 
      there is no flow tables found in the datapath.

  c)   The vxlan configuration such as the configured vxlan tunnel valuse does not exist in 
        the datapath, so these packets will be sent to vswitchd process. (There is only one vxlan tunnel 
       with vni value 0 exist in the datapath’s vxlan configuration).

2) root cause analysis

     a) For the unwanted packets(no vxlan tunnel configured for this case), the receiver will install the 
         drop-action flow to the datapath.

    b)  when the revalidator thread is trying to age-out/clean-up the flows installed in step 1), they are 
           considered as invalidate by revalidator thread since the revalidator thread could not find the 
          xport for them. Hence the revalidator thread delete the them very soon.

    c) That causes all the upcoming packets are sending to userspace again and  repeat the steps that   
            i) send to userspace, ii)) install drop-action flow table iii) the revalidator thread delete them.

3)) The fix is:
  if the flow's action is drop, we only bank on the time age-out mechanism to clean them up and don't enforce the revalidate_ukey action for them.
 