### PR TITLE
Add statistics of ovs-dpctl dump-flows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -71,6 +71,8 @@ v2.12.0 - xx xxx xxxx
      * Support for the kernel version 5.0.x.
    - 'ovs-dpctl dump-flows' is no longer suitable for dumping offloaded flows.
      'ovs-appctl dpctl/dump-flows' should be used instead.
+     'ovs-dpctl dump-flows' and 'ovs-appctl dpctl/dump-flows' add option argument
+       '--counters' to count the flow tables.
    - Add L2 GRE tunnel over IPv6 support.
 
 

--- a/lib/dpctl.c
+++ b/lib/dpctl.c
@@ -1073,8 +1073,12 @@ dpctl_dump_flows(int argc, const char *argv[], struct dpctl_params *dpctl_p)
 
     if (dpctl_p->counters) {
         ds_clear(&ds);
-        ds_put_format(&ds, "flows statistics: ovs %u, offloaded %u\n",
-                      nb_ovs, nb_offloaded);
+        if (dpctl_p->is_appctl) {
+            ds_put_format(&ds, "flows statistics: ovs %u, offloaded %u\n",
+                          nb_ovs, nb_offloaded);
+        } else {
+            ds_put_format(&ds, "flows statistics: ovs %u\n", nb_ovs);
+        }
         dpctl_print(dpctl_p, "%s\n", ds_cstr(&ds));
     }
 

--- a/lib/dpctl.h
+++ b/lib/dpctl.h
@@ -30,6 +30,9 @@ struct dpctl_params {
     /* --clear: Reset existing statistics to zero when modifying a flow? */
     bool zero_statistics;
 
+    /* --counters: Count the flows numbers */
+    bool counters;
+
     /* --may-create: Allow mod-flows command to create a new flow? */
     bool may_create;
 

--- a/lib/dpctl.man
+++ b/lib/dpctl.man
@@ -104,11 +104,13 @@ default.  When multiple datapaths exist, then a datapath name is
 required.
 .
 .TP
-.DO "[\fB\-m \fR| \fB\-\-more\fR] [\fB\-\-names \fR| \fB\-\-no\-names\fR]" \*(DX\fBdump\-flows\fR "[\fIdp\fR] [\fBfilter=\fIfilter\fR] [\fBtype=\fItype\fR]"
+.DO "[\fB\-m \fR| \fB\-\-more\fR] [\fB\-\-names \fR| \fB\-\-no\-names\fR] [\fB\-\-counters\fR]" \*(DX\fBdump\-flows\fR "[\fIdp\fR] [\fBfilter=\fIfilter\fR] [\fBtype=\fItype\fR]"
 Prints to the console all flow entries in datapath \fIdp\fR's flow
 table.  Without \fB\-m\fR or \fB\-\-more\fR, output omits match fields
 that a flow wildcards entirely; with \fB\-m\fR or \fB\-\-more\fR,
 output includes all wildcarded fields.
+.IP
+With \fB\-\-counters\fR, only output the counters of flow tables statistics.
 .IP
 If \fBfilter=\fIfilter\fR is specified, only displays the flows
 that match the \fIfilter\fR. \fIfilter\fR is a flow in the form similiar

--- a/utilities/ovs-dpctl.c
+++ b/utilities/ovs-dpctl.c
@@ -220,6 +220,7 @@ usage(void *userdata OVS_UNUSED)
            "\nOptions for dump-flows:\n"
            "  -m, --more                  increase verbosity of output\n"
            "  --names                     use port names in output\n"
+           "  --counters                  only display the counters of flow table statistics\n"
            "\nOptions for mod-flow:\n"
            "  --may-create                create flow if it doesn't exist\n"
            "  --read-only                 do not run read/write commands\n"

--- a/utilities/ovs-dpctl.c
+++ b/utilities/ovs-dpctl.c
@@ -76,6 +76,7 @@ parse_options(int argc, char *argv[])
 {
     enum {
         OPT_CLEAR = UCHAR_MAX + 1,
+        OPT_COUNTERS,
         OPT_MAY_CREATE,
         OPT_READ_ONLY,
         OPT_NAMES,
@@ -85,6 +86,7 @@ parse_options(int argc, char *argv[])
     static const struct option long_options[] = {
         {"statistics", no_argument, NULL, 's'},
         {"clear", no_argument, NULL, OPT_CLEAR},
+        {"counters", no_argument, NULL, OPT_COUNTERS},
         {"may-create", no_argument, NULL, OPT_MAY_CREATE},
         {"read-only", no_argument, NULL, OPT_READ_ONLY},
         {"more", no_argument, NULL, 'm'},
@@ -117,6 +119,10 @@ parse_options(int argc, char *argv[])
 
         case OPT_CLEAR:
             dpctl_p.zero_statistics = true;
+            break;
+
+        case OPT_COUNTERS:
+            dpctl_p.counters = true;
             break;
 
         case OPT_MAY_CREATE:


### PR DESCRIPTION
When running command ovs-dpctl dump-flows --counters, or
command ovs-appctl/dpctl dump-flows --counters, it will
display the number of kernel flows and offloaded flows.

The command will displayed as below:

ovs-appctl dpctl/dump-flows --counters
flows statistics: ovs 4, offloaded 2

ovs-dpctl dump-flows --counters
flows statistics: ovs 4

Signed-off-by: zhaozhanxu <zhaozhanxu@163.com>