### PR TITLE
bridge: Update stp,rstp statistics every stats-update-interval seconds.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,12 @@ Post-v2.12.0
      * DPDK pdump packet capture support disabled by default. New configure
        option '--enable-dpdk-pdump' to enable it.
      * DPDK pdump support is deprecated and will be removed in next releases.
+   - STP:
+     * The stp_sec_in_state field has been moved from Port status column to
+       Port statistics column.
+   - RSTP:
+     * The rstp_statistics column in Port table will only be updated every
+       stats-update-interval configured in Open_vSwtich table.
 
 v2.12.0 - 03 Sep 2019
 ---------------------

--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -2829,7 +2829,6 @@ get_stp_port_status(struct ofport *ofport_,
 
     s->enabled = true;
     stp_port_get_status(sp, &s->port_id, &s->state, &s->role);
-    s->sec_in_state = (time_msec() - ofport->stp_state_entered) / 1000;
 
     return 0;
 }
@@ -2849,6 +2848,7 @@ get_stp_port_stats(struct ofport *ofport_,
 
     s->enabled = true;
     stp_port_get_counts(sp, &s->tx_count, &s->rx_count, &s->error_count);
+    s->sec_in_state = (time_msec() - ofport->stp_state_entered) / 1000;
 
     return 0;
 }

--- a/ofproto/ofproto.h
+++ b/ofproto/ofproto.h
@@ -166,7 +166,6 @@ struct ofproto_port_stp_status {
     bool enabled;               /* If false, ignore other members. */
     int port_id;
     enum stp_state state;
-    unsigned int sec_in_state;
     enum stp_role role;
 };
 
@@ -175,6 +174,7 @@ struct ofproto_port_stp_stats {
     int tx_count;               /* Number of BPDUs transmitted. */
     int rx_count;               /* Number of valid BPDUs received. */
     int error_count;            /* Number of bad BPDUs received. */
+    unsigned int sec_in_state;  /* Number of secs in stp state. */
 };
 
 struct ofproto_port_queue {

--- a/vswitchd/vswitch.xml
+++ b/vswitchd/vswitch.xml
@@ -2144,11 +2144,6 @@
                       "forwarding", "blocking"]]}'>
           STP state of the port.
         </column>
-        <column name="status" key="stp_sec_in_state"
-                type='{"type": "integer", "minInteger": 0}'>
-          The amount of time this port has been in the current STP state, in
-          seconds.
-        </column>
         <column name="status" key="stp_role"
                 type='{"type": "string", "enum": ["set",
                       ["root", "designated", "alternate"]]}'>
@@ -2359,6 +2354,12 @@
         <column name="statistics" key="stp_error_count">
           Number of bad STP BPDUs received on this port.  Bad BPDUs
           include runt packets and those with an unexpected protocol ID.
+        </column>
+        <column name="statistics" key="stp_sec_in_state"
+                type='{"type": "integer", "minInteger": 0}'>
+          The amount of time this port has been in the current STP state, in
+          seconds.In Open vSwitch 2.12 and earlier this field was part of STP
+          Status.
         </column>
       </group>
     </group>


### PR DESCRIPTION
        Moves the field sec_in_state field from status column in Port table
        to statistics column in the same table.This helps in reducing the number
        of update sent to the controller, with the current mechanism
        every-time there is a change in this field a notification is sent to
        the controller. For this field its every second, since it's just
        counting the number of secs it has been in that particular state.
        By moving this under port statistics, this can be configured with the key
        "stats-update-interval" in Open_vSwitch table.

        Split the update of rstp_statistics column  and rstp_status column in
        Port table into two different functions.This helps in controlling the
        number of times the rstp_statistics column is updated with the key
        "stats-update_interval" in Open_vSwitch table.