### PR TITLE
bridge: Update stp,rstp statistics every stats-update-interval seconds.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,12 @@ Post-v2.12.0
      * DPDK pdump packet capture support disabled by default. New configure
        option '--enable-dpdk-pdump' to enable it.
      * DPDK pdump support is deprecated and will be removed in next releases.
+   - STP:
+     * New option status-update-interval for stp/rstp status update is added
+       to control the frequency of the updates. The default is 1 second.
+   - RSTP:
+     * The rstp_statistics column in Port table will only be updated every
+       stats-update-interval configured in Open_vSwtich table.
 
 v2.12.0 - 03 Sep 2019
 ---------------------

--- a/vswitchd/vswitch.xml
+++ b/vswitchd/vswitch.xml
@@ -107,6 +107,21 @@
           Getting statistics more frequently can be achieved via OpenFlow.
         </p>
       </column>
+      <column name="other_config" key="status-update-interval"
+              type='{"type": "integer", "minInteger": 1000}'>
+        <p>
+          Interval for updating status to the database, in milliseconds.
+          This option will affect the update of the <code>status</code>
+          column in the following tables: <code>Port</code>, <code>Interface
+          </code>, <code>Mirror</code>.
+        </p>
+        <p>
+          Default value is 1000 ms.
+        </p>
+        <p>
+          Controlling the status update frequency can be achieved via OpenFlow.
+        </p>
+      </column>
 
       <column name="other_config" key="flow-restore-wait"
               type='{"type": "boolean"}'>
@@ -2144,10 +2159,11 @@
                       "forwarding", "blocking"]]}'>
           STP state of the port.
         </column>
-        <column name="status" key="stp_sec_in_state"
+        <column name="statistics" key="stp_sec_in_state"
                 type='{"type": "integer", "minInteger": 0}'>
           The amount of time this port has been in the current STP state, in
-          seconds.
+          seconds.In Open vSwitch 2.12 and earlier this field was part of STP
+          Status.
         </column>
         <column name="status" key="stp_role"
                 type='{"type": "string", "enum": ["set",


### PR DESCRIPTION
        Moves the field sec_in_state field from status column in Port table
        to statistics column in the same table.This helps in reducing the number
        of update sent to the controller, with the current mechanism
        every-time there is a change in this field a notification is sent to
        the controller. For this field its every second, since it's just
        counting the number of secs its been in that particular state.
        By moving this under port statistics, this can be configured with the key
        "stats-update-interval" in Open_vSwitch table.

        Split the update of rstp_statistics column  and rstp_status column in
        Port table into two different functions.This helps in controlling the
        number of times the rstp_statistics column is updated with the key
        "stats-update_interval" in Open_vSwitch table.

Signed-off-by: Krishna Kolakaluri <kkolakaluri@plume.com>