### PR TITLE
bridge: Allow user configurable update status and seperate rstp stats.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,12 @@ Post-v2.12.0
      * DPDK pdump packet capture support disabled by default. New configure
        option '--enable-dpdk-pdump' to enable it.
      * DPDK pdump support is deprecated and will be removed in next releases.
+   - STP:
+     * New option status-update-interval for stp/rstp status update is added
+       to control the frequency of the updates. The default is 1 second.
+   - RSTP:
+     * The rstp_statistics column in Port table will only be updated every
+       stats-update-interval configured in Open_vSwtich table.
 
 v2.12.0 - 03 Sep 2019
 ---------------------

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -240,6 +240,11 @@ static struct ovsdb_idl_txn *stats_txn;
 static int stats_timer_interval;
 static long long int stats_timer = LLONG_MIN;
 
+/* Each time this timer expires, the bridge fetches various status information
+ * such as for STP, RSTP, Bonding, etc and pushes them into the database. */
+static int status_timer_interval;
+static long long int status_timer = LLONG_MIN;
+
 /* Each time this timer expires, the bridge fetches the list of port/VLAN
  * membership that has been modified by the AA.
  */
@@ -2733,6 +2738,7 @@ port_refresh_stp_status(struct port *port)
     struct iface *iface;
     struct ofproto_port_stp_status status;
     struct smap smap;
+    int    state_intvl = LLONG_MIN;
 
     if (port_is_synthetic(port)) {
         return;
@@ -2758,7 +2764,11 @@ port_refresh_stp_status(struct port *port)
     smap_init(&smap);
     smap_add_format(&smap, "stp_port_id", "%d", status.port_id);
     smap_add(&smap, "stp_state", stp_state_name(status.state));
-    smap_add_format(&smap, "stp_sec_in_state", "%u", status.sec_in_state);
+    if (time_msec() >= state_intvl)
+    {
+        smap_add_format(&smap, "stp_sec_in_state", "%u", status.sec_in_state);
+        state_intvl = time_msec() + 5000;
+    }
     smap_add(&smap, "stp_role", stp_role_name(status.role));
     ovsrec_port_set_status(port->cfg, &smap);
     smap_destroy(&smap);
@@ -2840,8 +2850,6 @@ port_refresh_rstp_status(struct port *port)
     struct ofproto *ofproto = port->bridge->ofproto;
     struct iface *iface;
     struct ofproto_port_rstp_status status;
-    const char *keys[4];
-    int64_t int_values[4];
     struct smap smap;
 
     if (port_is_synthetic(port)) {
@@ -2861,7 +2869,6 @@ port_refresh_rstp_status(struct port *port)
 
     if (!status.enabled) {
         ovsrec_port_set_rstp_status(port->cfg, NULL);
-        ovsrec_port_set_rstp_statistics(port->cfg, NULL, NULL, 0);
         return;
     }
     /* Set Status column. */
@@ -2882,6 +2889,36 @@ port_refresh_rstp_status(struct port *port)
 
     ovsrec_port_set_rstp_status(port->cfg, &smap);
     smap_destroy(&smap);
+}
+
+static void
+port_refresh_rstp_stats(struct port *port)
+{
+    struct ofproto *ofproto = port->bridge->ofproto;
+    struct iface *iface;
+    struct ofproto_port_rstp_status status;
+    const char *keys[4];
+    int64_t int_values[4];
+
+    if (port_is_synthetic(port)) {
+        return;
+    }
+
+    /* RSTP doesn't currently support bonds. */
+    if (!ovs_list_is_singleton(&port->ifaces)) {
+        ovsrec_port_set_rstp_statistics(port->cfg, NULL, NULL, 0);
+        return;
+    }
+
+    iface = CONTAINER_OF(ovs_list_front(&port->ifaces), struct iface, port_elem);
+    if (ofproto_port_get_rstp_status(ofproto, iface->ofp_port, &status)) {
+        return;
+    }
+
+    if (!status.enabled) {
+        ovsrec_port_set_rstp_statistics(port->cfg, NULL, NULL, 0);
+        return;
+    }
 
     /* Set Statistics column. */
     keys[0] = "rstp_tx_count";
@@ -3050,6 +3087,7 @@ run_stats_update(void)
                         iface_refresh_stats(iface);
                     }
                     port_refresh_stp_stats(port);
+                    port_refresh_rstp_stats(port);
                 }
                 HMAP_FOR_EACH (m, hmap_node, &br->mirrors) {
                     mirror_refresh_stats(m);
@@ -3086,7 +3124,9 @@ run_status_update(void)
     if (!status_txn) {
         uint64_t seq;
 
-        /* Rate limit the update.  Do not start a new update if the
+
+
+        /* Rate limit the update and do not start a new update if the
          * previous one is not done. */
         seq = seq_read(connectivity_seq_get());
         if (seq != connectivity_seqno || status_txn_try_again) {
@@ -3127,6 +3167,7 @@ run_status_update(void)
         status = ovsdb_idl_txn_commit(status_txn);
         if (status != TXN_INCOMPLETE) {
             ovsdb_idl_txn_destroy(status_txn);
+            status_timer = time_msec() + status_timer_interval;
             status_txn = NULL;
 
             /* Sets the 'status_txn_try_again' if the transaction fails. */

--- a/vswitchd/vswitch.xml
+++ b/vswitchd/vswitch.xml
@@ -107,6 +107,21 @@
           Getting statistics more frequently can be achieved via OpenFlow.
         </p>
       </column>
+      <column name="other_config" key="status-update-interval"
+              type='{"type": "integer", "minInteger": 1000}'>
+        <p>
+          Interval for updating status to the database, in milliseconds.
+          This option will affect the update of the <code>status</code>
+          column in the following tables: <code>Port</code>, <code>Interface
+          </code>, <code>Mirror</code>.
+        </p>
+        <p>
+          Default value is 1000 ms.
+        </p>
+        <p>
+          Controlling the status update frequency can be achieved via OpenFlow.
+        </p>
+      </column>
 
       <column name="other_config" key="flow-restore-wait"
               type='{"type": "boolean"}'>
@@ -2144,10 +2159,11 @@
                       "forwarding", "blocking"]]}'>
           STP state of the port.
         </column>
-        <column name="status" key="stp_sec_in_state"
+        <column name="statistics" key="stp_sec_in_state"
                 type='{"type": "integer", "minInteger": 0}'>
           The amount of time this port has been in the current STP state, in
-          seconds.
+          seconds.In Open vSwitch 2.12 and earlier this field was part of STP
+          Status.
         </column>
         <column name="status" key="stp_role"
                 type='{"type": "string", "enum": ["set",


### PR DESCRIPTION
	This commit adds a new configuration "status-update-interval" in
	"other_config" of Open_vSwitch table. This helps in reducing the number
        of updates sent to the controller, by configuring this value greater
	than 1s.

        Split the update of rstp_statistics column  and rstp_status column in
        Port table into two different functions.This helps in controlling the
        number of times the rstp_statistics column is updated with the key
        "stats-update_interval" in Open_vSwitch table.

Signed-off-by: Krishna Kolakaluri <kkolakaluri@plume.com>