### PR TITLE
bridge: Update stp_sec_in_state field every 5s and seperate rstp stats.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,9 @@ Post-v2.12.0
      * DPDK pdump packet capture support disabled by default. New configure
        option '--enable-dpdk-pdump' to enable it.
      * DPDK pdump support is deprecated and will be removed in next releases.
+   - RSTP:
+     * The rstp_statistics column in Port table will only be updated every
+       stats-update-interval configured in Open_vSwtich table.
 
 v2.12.0 - 03 Sep 2019
 ---------------------

--- a/vswitchd/vswitch.xml
+++ b/vswitchd/vswitch.xml
@@ -2144,10 +2144,11 @@
                       "forwarding", "blocking"]]}'>
           STP state of the port.
         </column>
-        <column name="status" key="stp_sec_in_state"
+        <column name="statistics" key="stp_sec_in_state"
                 type='{"type": "integer", "minInteger": 0}'>
           The amount of time this port has been in the current STP state, in
-          seconds.
+          seconds.In Open vSwitch 2.12 and earlier this field was part of STP
+          Status.
         </column>
         <column name="status" key="stp_role"
                 type='{"type": "string", "enum": ["set",


### PR DESCRIPTION
	"stp_sec_in_state" field in status column of the Port is causing too
	many updates to the controller. As per the suggestion added a 5s interval
	in between the updates of the field.

        Split the update of rstp_statistics column  and rstp_status column in
        Port table into two different functions.This helps in controlling the
        number of times the rstp_statistics column is updated with the key
        "stats-update_interval" in Open_vSwitch table.

Signed-off-by: Krishna Kolakaluri <kkolakaluri@plume.com>