### PR TITLE
vswitchd: Add serial number configuration.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,9 @@ Post-v2.12.0
        interval is increased to 60 seconds for the connection to the
        replication server. This value is configurable with the unixctl
        command - ovsdb-server/set-active-ovsdb-server-probe-interval.
+   - OpenFlow:
+     * The OpenFlow ofp_desc/serial_num may now be configured by setting the
+       value of other-config:dp-sn in the Bridge table.
 
 v2.12.0 - 03 Sep 2019
 ---------------------

--- a/ofproto/ofproto.c
+++ b/ofproto/ofproto.c
@@ -815,6 +815,13 @@ ofproto_set_dp_desc(struct ofproto *p, const char *dp_desc)
     p->dp_desc = nullable_xstrdup(dp_desc);
 }
 
+void
+ofproto_set_serial_desc(struct ofproto *p, const char *serial_desc)
+{
+    free(p->serial_desc);
+    p->serial_desc = nullable_xstrdup(serial_desc);
+}
+
 int
 ofproto_set_snoops(struct ofproto *ofproto, const struct sset *snoops)
 {

--- a/ofproto/ofproto.h
+++ b/ofproto/ofproto.h
@@ -351,6 +351,7 @@ void ofproto_set_threads(int n_handlers, int n_revalidators);
 void ofproto_type_set_config(const char *type,
                              const struct smap *other_config);
 void ofproto_set_dp_desc(struct ofproto *, const char *dp_desc);
+void ofproto_set_serial_desc(struct ofproto *p, const char *serial_desc);
 int ofproto_set_snoops(struct ofproto *, const struct sset *snoops);
 int ofproto_set_netflow(struct ofproto *,
                         const struct netflow_options *nf_options);

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -287,6 +287,7 @@ static void bridge_configure_ipfix(struct bridge *);
 static void bridge_configure_spanning_tree(struct bridge *);
 static void bridge_configure_tables(struct bridge *);
 static void bridge_configure_dp_desc(struct bridge *);
+static void bridge_configure_serial_desc(struct bridge *);
 static void bridge_configure_aa(struct bridge *);
 static void bridge_aa_refresh_queued(struct bridge *);
 static bool bridge_aa_need_refresh(struct bridge *);
@@ -938,6 +939,7 @@ bridge_reconfigure(const struct ovsrec_open_vswitch *ovs_cfg)
         bridge_configure_spanning_tree(br);
         bridge_configure_tables(br);
         bridge_configure_dp_desc(br);
+        bridge_configure_serial_desc(br);
         bridge_configure_aa(br);
     }
     free(managers);
@@ -4119,6 +4121,13 @@ bridge_configure_dp_desc(struct bridge *br)
 {
     ofproto_set_dp_desc(br->ofproto,
                         smap_get(&br->cfg->other_config, "dp-desc"));
+}
+
+static void
+bridge_configure_serial_desc(struct bridge *br)
+{
+    ofproto_set_serial_desc(br->ofproto,
+                        smap_get(&br->cfg->other_config, "dp-sn"));
 }
 
 static struct aa_mapping *

--- a/vswitchd/vswitch.xml
+++ b/vswitchd/vswitch.xml
@@ -1241,15 +1241,18 @@
         Human readable description of datapath.  It is a maximum 256
         byte-long free-form string to describe the datapath for
         debugging purposes, e.g. <code>switch3 in room 3120</code>.
+        The value is returned by the switch as a part of reply to OFPMP_DESC 
+        request (ofp_desc). The OpenFlow specification (e.g. 1.3.5) describes
+        the ofp_desc structure to contaion "NULL terminated ASCII strings".
+        For the compatibility reasons no more than 255 ASCII characters should be used.
       </column>
 
       <column name="other_config" key="dp-sn">
-        Serial number.  It is a maximum 32 byte-long free-form string to
+        Serial number. It is a maximum 32 byte-long free-form string to
         provide an additional switch identification. The value is returned
         by the switch as a part of reply to OFPMP_DESC request (ofp_desc).
-        The OpenFlow specification (e.g. 1.3.5) describes the ofp_desc structure
-        to contaion "NULL terminated ASCII strings". For the compatibility
-        reasons no more than 31 ASCII characters should be used.
+        Same as mentioned in the description of <ref column="other-config" key="dp-desc"/>,
+        the string should be no more than 31 ASCII characters for the compatibility.
       </column>
 
       <column name="other_config" key="disable-in-band"

--- a/vswitchd/vswitch.xml
+++ b/vswitchd/vswitch.xml
@@ -1243,6 +1243,15 @@
         debugging purposes, e.g. <code>switch3 in room 3120</code>.
       </column>
 
+      <column name="other_config" key="dp-sn">
+        Serial number.  It is a maximum 32 byte-long free-form string to
+        provide an additional switch identification. The value is returned
+        by the switch as a part of reply to OFPMP_DESC request (ofp_desc).
+        The OpenFlow specification (e.g. 1.3.5) describes the ofp_desc structure
+        to contaion "NULL terminated ASCII strings". For the compatibility
+        reasons no more than 31 ASCII characters should be used.
+      </column>
+
       <column name="other_config" key="disable-in-band"
               type='{"type": "boolean"}'>
         If set to <code>true</code>, disable in-band control on the bridge


### PR DESCRIPTION
There was no way to initialize the serial number in ofproto.c.
Added it as a configuration parameter "dp-sn"