### PR TITLE
Fd persistence

### DIFF
--- a/include/openvswitch/poll-loop.h
+++ b/include/openvswitch/poll-loop.h
@@ -41,6 +41,12 @@
 #include <windows.h>
 #endif
 
+#define OVS_POLLIN POLLIN
+#define OVS_POLLOUT POLLOUT
+#define OVS_POLLERR POLLERR
+#define OVS_POLLNVAL POLLNVAL
+#define OVS_POLLHUP POLLHUP
+
 #ifdef  __cplusplus
 extern "C" {
 #endif

--- a/lib/fatal-signal.c
+++ b/lib/fatal-signal.c
@@ -271,7 +271,7 @@ fatal_signal_wait(void)
 #ifdef _WIN32
     poll_wevent_wait(wevent);
 #else
-    poll_fd_wait(signal_fds[0], POLLIN);
+    poll_fd_wait(signal_fds[0], OVS_POLLIN);
 #endif
 }
 

--- a/lib/fatal-signal.c
+++ b/lib/fatal-signal.c
@@ -96,6 +96,7 @@ fatal_signal_init(void)
         ovs_mutex_init_recursive(&mutex);
 #ifndef _WIN32
         xpipe_nonblocking(signal_fds);
+        poll_fd_register(signal_fds[0], OVS_POLLIN, NULL);
 #else
         wevent = CreateEvent(NULL, TRUE, FALSE, NULL);
         if (!wevent) {
@@ -236,8 +237,11 @@ void
 fatal_signal_run(void)
 {
     sig_atomic_t sig_nr;
+    char sigbuffer[_POSIX_PIPE_BUF];
 
     fatal_signal_init();
+
+    read(signal_fds[0], sigbuffer, sizeof(sigbuffer));
 
     sig_nr = stored_sig_nr;
     if (sig_nr != SIG_ATOMIC_MAX) {

--- a/lib/jsonrpc.c
+++ b/lib/jsonrpc.c
@@ -266,7 +266,7 @@ jsonrpc_send(struct jsonrpc *rpc, struct jsonrpc_msg *msg)
                      rpc->output_count, rpc->backlog);
     }
 
-    if (rpc->backlog == length) {
+    if (rpc->backlog >= length) {
         jsonrpc_run(rpc);
     }
     return rpc->status;

--- a/lib/latch-unix.c
+++ b/lib/latch-unix.c
@@ -67,7 +67,7 @@ latch_is_set(const struct latch *latch)
     int retval;
 
     pfd.fd = latch->fds[0];
-    pfd.events = POLLIN;
+    pfd.events = POLLIN; /* This is POLL specific, it should use POLL only macro */
     do {
         retval = poll(&pfd, 1, 0);
     } while (retval < 0 && errno == EINTR);
@@ -83,5 +83,5 @@ latch_is_set(const struct latch *latch)
 void
 latch_wait_at(const struct latch *latch, const char *where)
 {
-    poll_fd_wait_at(latch->fds[0], POLLIN, where);
+    poll_fd_wait_at(latch->fds[0], OVS_POLLIN, where);
 }

--- a/lib/latch-unix.c
+++ b/lib/latch-unix.c
@@ -28,12 +28,14 @@ void
 latch_init(struct latch *latch)
 {
     xpipe_nonblocking(latch->fds);
+    poll_fd_register(latch->fds[0], OVS_POLLIN | OVS_ONESHOT, NULL); /* register, but not set any events */
 }
 
 /* Destroys 'latch'. */
 void
 latch_destroy(struct latch *latch)
 {
+    poll_fd_deregister(latch->fds[0]);
     close(latch->fds[0]);
     close(latch->fds[1]);
 }
@@ -83,5 +85,6 @@ latch_is_set(const struct latch *latch)
 void
 latch_wait_at(const struct latch *latch, const char *where)
 {
-    poll_fd_wait_at(latch->fds[0], OVS_POLLIN, where);
+    /* Ask for wait and make it one-shot if persistence is in play */
+    poll_fd_wait_at(latch->fds[0], OVS_POLLIN | OVS_ONESHOT, where);
 }

--- a/lib/netdev-afxdp.c
+++ b/lib/netdev-afxdp.c
@@ -184,7 +184,7 @@ xsk_rx_wakeup_if_needed(struct xsk_umem_info *umem,
 
     if (xsk_ring_prod__needs_wakeup(&umem->fq)) {
         pfd.fd = fd;
-        pfd.events = OVS_POLLIN;
+        pfd.events = POLLIN;
 
         ret = poll(&pfd, 1, 0);
         if (OVS_UNLIKELY(ret < 0)) {

--- a/lib/netdev-afxdp.c
+++ b/lib/netdev-afxdp.c
@@ -184,7 +184,7 @@ xsk_rx_wakeup_if_needed(struct xsk_umem_info *umem,
 
     if (xsk_ring_prod__needs_wakeup(&umem->fq)) {
         pfd.fd = fd;
-        pfd.events = POLLIN;
+        pfd.events = OVS_POLLIN;
 
         ret = poll(&pfd, 1, 0);
         if (OVS_UNLIKELY(ret < 0)) {

--- a/lib/netdev-bsd.c
+++ b/lib/netdev-bsd.c
@@ -659,7 +659,7 @@ netdev_bsd_rxq_wait(struct netdev_rxq *rxq_)
 {
     struct netdev_rxq_bsd *rxq = netdev_rxq_bsd_cast(rxq_);
 
-    poll_fd_wait(rxq->fd, POLLIN);
+    poll_fd_wait(rxq->fd, OVS_POLLIN);
 }
 
 /* Discards all packets waiting to be received from 'rxq'. */
@@ -752,7 +752,7 @@ netdev_bsd_send_wait(struct netdev *netdev_, int qid OVS_UNUSED)
         /* TAP device always accepts packets. */
         poll_immediate_wake();
     } else if (dev->pcap) {
-        poll_fd_wait(dev->fd, POLLOUT);
+        poll_fd_wait(dev->fd, OVS_POLLOUT);
     } else {
         /* We haven't even tried to send a packet yet. */
         poll_immediate_wake();

--- a/lib/netdev-linux.c
+++ b/lib/netdev-linux.c
@@ -1149,6 +1149,10 @@ netdev_linux_rxq_construct(struct netdev_rxq *rxq_)
             goto error;
         }
     }
+    /* Register with persistent event frameworks if available - this
+     * should be able to grab both raw and tap cases
+     */
+    poll_fd_register(rx->fd, OVS_POLLIN, NULL);
     ovs_mutex_unlock(&netdev->mutex);
 
     return 0;
@@ -1166,6 +1170,8 @@ netdev_linux_rxq_destruct(struct netdev_rxq *rxq_)
 {
     struct netdev_rxq_linux *rx = netdev_rxq_linux_cast(rxq_);
     int i;
+
+    poll_fd_deregister(rx->fd);
 
     if (!rx->is_tap) {
         close(rx->fd);

--- a/lib/netdev-linux.c
+++ b/lib/netdev-linux.c
@@ -808,7 +808,7 @@ netdev_linux_wait(const struct netdev_class *netdev_class OVS_UNUSED)
     }
     sock = netdev_linux_notify_sock();
     if (sock) {
-        nl_sock_wait(sock, POLLIN);
+        nl_sock_wait(sock, OVS_POLLIN);
     }
 }
 
@@ -1465,7 +1465,7 @@ static void
 netdev_linux_rxq_wait(struct netdev_rxq *rxq_)
 {
     struct netdev_rxq_linux *rx = netdev_rxq_linux_cast(rxq_);
-    poll_fd_wait(rx->fd, POLLIN);
+    poll_fd_wait(rx->fd, OVS_POLLIN);
 }
 
 static int

--- a/lib/netlink-notifier.c
+++ b/lib/netlink-notifier.c
@@ -1,4 +1,5 @@
 /*
+
  * Copyright (c) 2009, 2010, 2011, 2012, 2013, 2016 Nicira, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +28,7 @@
 #include "netlink-socket.h"
 #include "openvswitch/ofpbuf.h"
 #include "openvswitch/vlog.h"
+#include "openvswitch/poll-loop.h"
 
 VLOG_DEFINE_THIS_MODULE(netlink_notifier);
 
@@ -219,7 +221,7 @@ nln_wait(struct nln *nln)
 {
     nln->has_run = false;
     if (nln->notify_sock) {
-        nl_sock_wait(nln->notify_sock, POLLIN);
+        nl_sock_wait(nln->notify_sock, OVS_POLLIN);
     }
 }
 

--- a/lib/netlink-socket.c
+++ b/lib/netlink-socket.c
@@ -230,6 +230,9 @@ nl_sock_create(int protocol, struct nl_sock **sockp)
     sock->pid = local.nl_pid;
 #endif
 
+    /* Register socket persistently where supported */
+    poll_fd_register(sock->fd, OVS_POLLIN, NULL);
+
     *sockp = sock;
     return 0;
 
@@ -276,6 +279,7 @@ nl_sock_destroy(struct nl_sock *sock)
         }
         CloseHandle(sock->handle);
 #else
+        poll_fd_deregister(sock->fd);
         close(sock->fd);
 #endif
         free(sock);

--- a/lib/poll-loop.c
+++ b/lib/poll-loop.c
@@ -80,7 +80,7 @@ find_poll_node(struct poll_loop *loop, int fd, HANDLE wevent)
 /* On Unix based systems:
  *
  *     Registers 'fd' as waiting for the specified 'events' (which should be
- *     POLLIN or POLLOUT or POLLIN | POLLOUT).  The following call to
+ *     OVS_POLLIN or OVS_POLLOUT or OVS_POLLIN | OVS_POLLOUT).  The following call to
  *     poll_block() will wake up when 'fd' becomes ready for one or more of the
  *     requested events. The 'fd's are given to poll() function later.
  *
@@ -130,8 +130,8 @@ poll_create_node(int fd, HANDLE wevent, short int events, const char *where)
     }
 }
 
-/* Registers 'fd' as waiting for the specified 'events' (which should be POLLIN
- * or POLLOUT or POLLIN | POLLOUT).  The following call to poll_block() will
+/* Registers 'fd' as waiting for the specified 'events' (which should be OVS_POLLIN
+ * or OVS_POLLOUT or OVS_POLLIN | OVS_POLLOUT).  The following call to poll_block() will
  * wake up when 'fd' becomes ready for one or more of the requested events.
  *
  * On Windows, 'fd' must be a socket.
@@ -265,20 +265,20 @@ log_wakeup(const char *where, const struct pollfd *pollfd, int timeout)
     ds_put_cstr(&s, "wakeup due to ");
     if (pollfd) {
         char *description = describe_fd(pollfd->fd);
-        if (pollfd->revents & POLLIN) {
-            ds_put_cstr(&s, "[POLLIN]");
+        if (pollfd->revents & OVS_POLLIN) {
+            ds_put_cstr(&s, "[OVS_POLLIN]");
         }
-        if (pollfd->revents & POLLOUT) {
-            ds_put_cstr(&s, "[POLLOUT]");
+        if (pollfd->revents & OVS_POLLOUT) {
+            ds_put_cstr(&s, "[OVS_POLLOUT]");
         }
-        if (pollfd->revents & POLLERR) {
-            ds_put_cstr(&s, "[POLLERR]");
+        if (pollfd->revents & OVS_POLLERR) {
+            ds_put_cstr(&s, "[OVS_POLLERR]");
         }
-        if (pollfd->revents & POLLHUP) {
-            ds_put_cstr(&s, "[POLLHUP]");
+        if (pollfd->revents & OVS_POLLHUP) {
+            ds_put_cstr(&s, "[OVS_POLLHUP]");
         }
-        if (pollfd->revents & POLLNVAL) {
-            ds_put_cstr(&s, "[POLLNVAL]");
+        if (pollfd->revents & OVS_POLLNVAL) {
+            ds_put_cstr(&s, "[OVS_POLLNVAL]");
         }
         ds_put_format(&s, " on fd %d (%s)", pollfd->fd, description);
         free(description);
@@ -349,10 +349,10 @@ poll_block(void)
         wevents[i] = node->wevent;
         if (node->pollfd.fd && node->wevent) {
             short int wsa_events = 0;
-            if (node->pollfd.events & POLLIN) {
+            if (node->pollfd.events & OVS_POLLIN) {
                 wsa_events |= FD_READ | FD_ACCEPT | FD_CLOSE;
             }
-            if (node->pollfd.events & POLLOUT) {
+            if (node->pollfd.events & OVS_POLLOUT) {
                 wsa_events |= FD_WRITE | FD_CONNECT | FD_CLOSE;
             }
             WSAEventSelect(node->pollfd.fd, node->wevent, wsa_events);

--- a/lib/process.c
+++ b/lib/process.c
@@ -592,7 +592,7 @@ process_wait(struct process *p)
     if (p->exited) {
         poll_immediate_wake();
     } else {
-        poll_fd_wait(fds[0], POLLIN);
+        poll_fd_wait(fds[0], OVS_POLLIN);
     }
 #else
     OVS_NOT_REACHED();

--- a/lib/process.c
+++ b/lib/process.c
@@ -592,6 +592,8 @@ process_wait(struct process *p)
     if (p->exited) {
         poll_immediate_wake();
     } else {
+        /* Register fd persistently where supported */
+        poll_fd_register(fds[0], OVS_POLLIN, NULL);
         poll_fd_wait(fds[0], OVS_POLLIN);
     }
 #else

--- a/lib/route-table-bsd.c
+++ b/lib/route-table-bsd.c
@@ -34,6 +34,7 @@
 #include "ovs-router.h"
 #include "packets.h"
 #include "openvswitch/vlog.h"
+#include "openvswitch/poll-loop.h"
 #include "util.h"
 
 VLOG_DEFINE_THIS_MODULE(route_table_bsd);

--- a/lib/route-table-bsd.c
+++ b/lib/route-table-bsd.c
@@ -113,7 +113,7 @@ retry:
 
         memset(&pfd, 0, sizeof(pfd));
         pfd.fd = rtsock;
-        pfd.events = POLLIN;
+        pfd.events = OVS_POLLIN;
         /*
          * The timeout value below is somehow arbitrary.
          * It's to detect the lost of routing messages due to

--- a/lib/rtbsd.c
+++ b/lib/rtbsd.c
@@ -159,7 +159,7 @@ rtbsd_notifier_wait(void)
 {
     ovs_mutex_lock(&rtbsd_mutex);
     if (notify_sock >= 0) {
-        poll_fd_wait(notify_sock, POLLIN);
+        poll_fd_wait(notify_sock, OVS_POLLIN);
     }
     ovs_mutex_unlock(&rtbsd_mutex);
 }

--- a/lib/socket-util.c
+++ b/lib/socket-util.c
@@ -259,7 +259,7 @@ check_connection_completion(int fd)
     int retval;
 
     pfd.fd = fd;
-    pfd.events = POLLOUT;
+    pfd.events = OVS_POLLOUT;
 
 #ifndef _WIN32
     do {
@@ -280,17 +280,17 @@ check_connection_completion(int fd)
             pfd.revents |= pfd.events;
         }
         if (FD_ISSET(fd, &exset)) {
-            pfd.revents |= POLLERR;
+            pfd.revents |= OVS_POLLERR;
         }
     }
 #endif
     if (retval == 1) {
-        if (pfd.revents & (POLLERR | POLLHUP)) {
+        if (pfd.revents & (OVS_POLLERR | OVS_POLLHUP)) {
             ssize_t n = send(fd, "", 1, 0);
             if (n < 0) {
                 return sock_errno();
             } else {
-                VLOG_ERR_RL(&rl, "poll return POLLERR but send succeeded");
+                VLOG_ERR_RL(&rl, "poll return OVS_POLLERR but send succeeded");
                 return EPROTO;
             }
         }

--- a/lib/stream-fd.c
+++ b/lib/stream-fd.c
@@ -150,11 +150,11 @@ fd_wait(struct stream *stream, enum stream_wait_type wait)
     switch (wait) {
     case STREAM_CONNECT:
     case STREAM_SEND:
-        poll_fd_wait(s->fd, POLLOUT);
+        poll_fd_wait(s->fd, OVS_POLLOUT);
         break;
 
     case STREAM_RECV:
-        poll_fd_wait(s->fd, POLLIN);
+        poll_fd_wait(s->fd, OVS_POLLIN);
         break;
 
     default:
@@ -271,7 +271,7 @@ static void
 pfd_wait(struct pstream *pstream)
 {
     struct fd_pstream *ps = fd_pstream_cast(pstream);
-    poll_fd_wait(ps->fd, POLLIN);
+    poll_fd_wait(ps->fd, OVS_POLLIN);
 }
 
 static const struct pstream_class fd_pstream_class = {

--- a/lib/stream-ssl.c
+++ b/lib/stream-ssl.c
@@ -210,10 +210,10 @@ want_to_poll_events(int want)
         OVS_NOT_REACHED();
 
     case SSL_READING:
-        return POLLIN;
+        return OVS_POLLIN;
 
     case SSL_WRITING:
-        return POLLOUT;
+        return OVS_POLLOUT;
 
     default:
         OVS_NOT_REACHED();
@@ -811,7 +811,7 @@ ssl_wait(struct stream *stream, enum stream_wait_type wait)
         } else {
             switch (sslv->state) {
             case STATE_TCP_CONNECTING:
-                poll_fd_wait(sslv->fd, POLLOUT);
+                poll_fd_wait(sslv->fd, OVS_POLLOUT);
                 break;
 
             case STATE_SSL_CONNECTING:
@@ -965,7 +965,7 @@ static void
 pssl_wait(struct pstream *pstream)
 {
     struct pssl_pstream *pssl = pssl_pstream_cast(pstream);
-    poll_fd_wait(pssl->fd, POLLIN);
+    poll_fd_wait(pssl->fd, OVS_POLLIN);
 }
 
 const struct pstream_class pssl_pstream_class = {

--- a/lib/stream-ssl.c
+++ b/lib/stream-ssl.c
@@ -147,6 +147,7 @@ struct ssl_stream
     /* A few bytes of header data in case SSL negotiation fails. */
     uint8_t head[2];
     short int n_head;
+    struct pollfd *hint;
 };
 
 /* SSL context created by ssl_init(). */
@@ -310,6 +311,8 @@ new_ssl_stream(char *name, char *server_name, int fd, enum session_type type,
         SSL_set_msg_callback_arg(ssl, sslv);
     }
 
+
+    poll_fd_register(sslv->fd, OVS_POLLIN, &sslv->hint);
     *streamp = &sslv->stream;
     free(server_name);
     return 0;
@@ -604,6 +607,7 @@ ssl_close(struct stream *stream)
     ERR_clear_error();
 
     SSL_free(sslv->ssl);
+    poll_fd_deregister(sslv->fd);
     closesocket(sslv->fd);
     free(sslv);
 }
@@ -697,6 +701,21 @@ ssl_recv(struct stream *stream, void *buffer, size_t n)
     /* Behavior of zero-byte SSL_read is poorly defined. */
     ovs_assert(n > 0);
 
+     if (sslv->hint) {
+        /* poll-loop is providing us with hints for IO */
+        if (sslv->rx_want == SSL_READING) {
+            if (!(sslv->hint->revents & OVS_POLLIN)) {
+                return -EAGAIN;
+            } else {
+                /* POLLIN event from poll loop, mark us as ready 
+                 * rx_want is cleared further down by reading ssl fsm
+                 */
+                sslv->hint->revents &= ~OVS_POLLIN;
+            }
+        }
+    }
+
+
     old_state = SSL_get_state(sslv->ssl);
     ret = SSL_read(sslv->ssl, buffer, n);
     if (old_state != SSL_get_state(sslv->ssl)) {
@@ -729,6 +748,19 @@ ssl_do_tx(struct stream *stream)
 {
     struct ssl_stream *sslv = ssl_stream_cast(stream);
 
+     if (sslv->hint) {
+        /* poll-loop is providing us with hints for IO */
+        if (sslv->tx_want == SSL_WRITING) {
+            if (!(sslv->hint->revents & OVS_POLLOUT)) {
+                return EAGAIN;
+            } else {
+                /* POLLIN event from poll loop, mark us as ready 
+                 * rx_want is cleared further down by reading ssl fsm
+                 */
+                sslv->hint->revents &= ~OVS_POLLOUT;
+            }
+        }
+    }
     for (;;) {
         int old_state = SSL_get_state(sslv->ssl);
         int ret = SSL_write(sslv->ssl, sslv->txbuf->data, sslv->txbuf->size);
@@ -771,6 +803,8 @@ ssl_send(struct stream *stream, const void *buffer, size_t n)
             ssl_clear_txbuf(sslv);
             return n;
         case EAGAIN:
+            /* we want to know when this fd will become available again */
+            stream_send_wait(stream);
             return n;
         default:
             ssl_clear_txbuf(sslv);
@@ -911,6 +945,7 @@ pssl_open(const char *name OVS_UNUSED, char *suffix, struct pstream **pstreamp,
                  ds_steal_cstr(&bound_name));
     pstream_set_bound_port(&pssl->pstream, htons(port));
     pssl->fd = fd;
+    poll_fd_register(fd, OVS_POLLIN, NULL);
     *pstreamp = &pssl->pstream;
 
     return 0;
@@ -920,6 +955,7 @@ static void
 pssl_close(struct pstream *pstream)
 {
     struct pssl_pstream *pssl = pssl_pstream_cast(pstream);
+    poll_fd_deregister(pssl->fd);
     closesocket(pssl->fd);
     free(pssl);
 }

--- a/lib/stream-unix.c
+++ b/lib/stream-unix.c
@@ -47,6 +47,7 @@ unix_open(const char *name, char *suffix, struct stream **streamp,
     char *connect_path;
     int fd;
 
+
     connect_path = abs_file_name(ovs_rundir(), suffix);
     fd = make_unix_socket(SOCK_STREAM, true, NULL, connect_path);
 

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -38,6 +38,7 @@
 #include "unixctl.h"
 #include "util.h"
 #include "openvswitch/vlog.h"
+#include "openvswitch/poll-loop.h"
 
 VLOG_DEFINE_THIS_MODULE(timeval);
 
@@ -368,6 +369,88 @@ time_poll(struct pollfd *pollfds, int n_pollfds, HANDLE *handles OVS_UNUSED,
     *elapsed = *last_wakeup - start;
     return retval;
 }
+
+#ifdef OVS_USE_EPOLL
+
+/* Like epoll_wait(), except:
+ *
+ *      - The timeout is specified as an absolute time, as defined by
+ *        time_msec(), instead of a duration.
+ *
+ *      - On error, returns a negative error code (instead of setting errno).
+ *
+ *      - If interrupted by a signal, retries automatically until the original
+ *        timeout is reached.  (Because of this property, this function will
+ *        never return -EINTR.)
+ *
+ * Stores the number of milliseconds elapsed during poll in '*elapsed'. */
+int
+time_epoll_wait(int epoll_fd, struct epoll_event *events, int max,
+          long long int timeout_when, int *elapsed)
+{
+    long long int *last_wakeup = last_wakeup_get();
+    long long int start;
+    bool quiescent;
+    int retval = 0;
+
+    time_init();
+    coverage_clear();
+    coverage_run();
+    if (*last_wakeup && !thread_is_pmd()) {
+        log_poll_interval(*last_wakeup);
+    }
+    start = time_msec();
+
+    timeout_when = MIN(timeout_when, deadline);
+    quiescent = ovsrcu_is_quiescent();
+
+    for (;;) {
+        long long int now = time_msec();
+        int time_left;
+
+        if (now >= timeout_when) {
+            time_left = 0;
+        } else if ((unsigned long long int) timeout_when - now > INT_MAX) {
+            time_left = INT_MAX;
+        } else {
+            time_left = timeout_when - now;
+        }
+
+        if (!quiescent) {
+            if (!time_left) {
+                ovsrcu_quiesce();
+            } else {
+                ovsrcu_quiesce_start();
+            }
+        }
+
+        retval = epoll_wait(epoll_fd, events, max, time_left);
+        if (retval < 0) {
+            retval = -errno;
+        }
+
+        if (!quiescent && time_left) {
+            ovsrcu_quiesce_end();
+        }
+
+        if (deadline <= time_msec()) {
+            fatal_signal_handler(SIGALRM);
+            if (retval < 0) {
+                retval = 0;
+            }
+            break;
+        }
+
+        if (retval != -EINTR) {
+            break;
+        }
+    }
+    *last_wakeup = time_msec();
+    refresh_rusage();
+    *elapsed = *last_wakeup - start;
+    return retval;
+}
+#endif
 
 long long int
 timespec_to_msec(const struct timespec *ts)

--- a/lib/timeval.h
+++ b/lib/timeval.h
@@ -20,6 +20,9 @@
 #include <time.h>
 #include "openvswitch/type-props.h"
 #include "util.h"
+#ifdef __linux__
+#include <sys/epoll.h>
+#endif
 
 #ifdef  __cplusplus
 extern "C" {
@@ -61,6 +64,10 @@ void time_wall_timespec(struct timespec *);
 void time_alarm(unsigned int secs);
 int time_poll(struct pollfd *, int n_pollfds, HANDLE *handles,
               long long int timeout_when, int *elapsed);
+#ifdef __linux__
+int time_epoll_wait(int epoll_fd, struct epoll_event *events, int max,
+          long long int timeout_when, int *elapsed);
+#endif
 
 long long int timespec_to_msec(const struct timespec *);
 long long int timespec_to_usec(const struct timespec *);

--- a/manpages.mk
+++ b/manpages.mk
@@ -104,7 +104,6 @@ utilities/bugtool/ovs-bugtool.8: \
 utilities/bugtool/ovs-bugtool.8.in:
 lib/ovs.tmac:
 
-
 utilities/ovs-dpctl-top.8: \
 	utilities/ovs-dpctl-top.8.in \
 	lib/ovs.tmac
@@ -153,8 +152,6 @@ utilities/ovs-pcap.1: \
 utilities/ovs-pcap.1.in:
 lib/common-syn.man:
 lib/common.man:
-lib/ovs.tmac:
-
 lib/ovs.tmac:
 
 utilities/ovs-testcontroller.8: \

--- a/tests/test-netflow.c
+++ b/tests/test-netflow.c
@@ -229,7 +229,7 @@ test_netflow_main(int argc, char *argv[])
             break;
         }
 
-        poll_fd_wait(sock, POLLIN);
+        poll_fd_wait(sock, OVS_POLLIN);
         unixctl_server_wait(server);
         poll_block();
     }

--- a/tests/test-sflow.c
+++ b/tests/test-sflow.c
@@ -739,7 +739,7 @@ test_sflow_main(int argc, char *argv[])
             break;
         }
 
-        poll_fd_wait(sock, POLLIN);
+        poll_fd_wait(sock, OVS_POLLIN);
         unixctl_server_wait(server);
         poll_block();
     }

--- a/utilities/nlmon.c
+++ b/utilities/nlmon.c
@@ -141,7 +141,7 @@ main(int argc OVS_UNUSED, char *argv[])
             }
         }
 
-        nl_sock_wait(sock, POLLIN);
+        nl_sock_wait(sock, OVS_POLLIN);
         poll_block();
     }
 }


### PR DESCRIPTION
This fixes:

1. The current practice of reading FDs without IO pending on them. This is a penalty of 0.3 microseconds per fd. So for example, ovsdb in OVN southdb with 200 nodes has a guaranteed penalty of 60 microseconds on every transaction. That does add up to quite a number in a large installation.

2. The poll loop to do what it is supposed to do according to its comments. It is supposed to be an implementation where the flags (POLLIN, POLLOUT, etc) are additive according to the comments. That is not the case, because if it gets an event which is just POLLIN it will wipe the POLLOUT from its state and vice versa.

3. Adds epoll support for Linux.

I will kill the older pull request with the incomplete linux only/epoll only patchset.