### PR TITLE
bond: Fix  command "ovs-appctl bond/disable-slave"  not in effect

### DIFF
--- a/ofproto/bond.c
+++ b/ofproto/bond.c
@@ -1744,6 +1744,10 @@ bond_link_status_update(struct bond_slave *slave)
 {
     struct bond *bond = slave->bond;
     bool up;
+    
+    if (!slave->enabled) {
+        return;
+    }
 
     up = netdev_get_carrier(slave->netdev) && slave->may_enable;
     if ((up == slave->enabled) != (slave->delay_expires == LLONG_MAX)) {


### PR DESCRIPTION
After disable one slave, it will be enable by the function "bond_link_status_update". 
the bond log like this : 
    2020-02-18T16:21:43.673Z|18945|bond|INFO|interface dpdk0: disabled
    2020-02-18T16:21:43.673Z|18946|bond|INFO|interface dpdk0: link state up
    2020-02-18T16:21:43.673Z|18947|bond|INFO|interface dpdk0: enabled