### PR TITLE
ipsec: Fix Strongswan configuration syntax

### DIFF
--- a/ipsec/ovs-monitor-ipsec.in
+++ b/ipsec/ovs-monitor-ipsec.in
@@ -145,10 +145,18 @@ class StrongSwanHelper(object):
     """This class does StrongSwan specific configurations."""
 
     STRONGSWAN_CONF = """%s
-charon.plugins.kernel-netlink.set_proto_port_transport_sa = yes
-charon.plugins.kernel-netlink.xfrm_ack_expires = 10
-charon.load_modular = yes
-charon.plugins.gcm.load = yes
+charon {
+  plugins {
+    kernel-netlink {
+      set_proto_port_transport_sa = yes
+      xfrm_ack_expires = 10
+    }
+    gcm {
+      load = yes
+    }
+  }
+  load_modular = yes
+}
 """ % (FILE_HEADER)
 
     CONF_HEADER = """%s


### PR DESCRIPTION
Strongswan seems to have .opt files in the source tree with the dotted option syntax. It seems that up until version 5.6, the syntax was also accepted by Strongswan.

However, the .opt files are converted to .conf files during Strongswan build, and the dotted syntax is no longer accepted by Strongswan (tested on 5.8.2).

The effect was that the ovs ipsec monitor fails to start Strongswan, since that complains with:
`/etc/strongswan.d/ovs.conf:4: syntax error, unexpected ., expecting : or '{' or '=' [.]`

I could not locate the exact code change in Strongswan that changed and caused this, but fact is that the *.conf files in /etc/strongswan.d have the same syntax as the PR suggests.