### PR TITLE
Force output flush in ovs-tcpdump

### DIFF
--- a/utilities/ovs-tcpdump.in
+++ b/utilities/ovs-tcpdump.in
@@ -490,7 +490,7 @@ def main():
             data = pipes.stdout.readline().strip(b'\n')
             if len(data) == 0:
                 raise KeyboardInterrupt
-            print(data.decode('utf-8'))
+            print(data.decode('utf-8'), flush=True)
         raise KeyboardInterrupt
     except KeyboardInterrupt:
         if pipes.poll() is None:


### PR DESCRIPTION
Currently `print()` might get buffered which will result in `BrokenPipeError` (`SIGPIPE`) in a garbage collection phase if `ovs-tcpdump` is piped. 

```sh
$ ovs-tcpdump -i eth0 | tee dump
# snip
^C7 packets captured
7 packets received by filter
0 packets dropped by kernel
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```

Proposed change only handles graceful exit and output corruption in buffered case. To properly exit in pipe failure case (`ovs-tcpdump -i eth0 | false`) `BrokenPipeError` needs to be handled explicitly, see Python [docs](https://docs.python.org/3/library/signal.html#note-on-sigpipe) on the issue.