### PR TITLE
Fix Windows incompatibility when setting new feature

### DIFF
--- a/lib/dpif-netlink.c
+++ b/lib/dpif-netlink.c
@@ -691,6 +691,7 @@ dpif_netlink_set_features(struct dpif *dpif_, uint32_t new_features)
 
     dpif_netlink_dp_init(&request);
     request.cmd = OVS_DP_CMD_SET;
+    request.name = dpif_->base_name;
     request.dp_ifindex = dpif->dp_ifindex;
     request.user_features = dpif->user_features | new_features;
 


### PR DESCRIPTION
OVS_DP_ATTR_NAME field is required when sending OVS_DP_CMD_SET to
windows kernel driver. The function "dpif_netlink_set_features"
dose not set the OVS_DP_ATTR_NAME field which will cause set feature
failure and ovs-vswitchd will exist.

This patch fixes the issue by setting "request.name" in request.

Fix https://github.com/openvswitch/ovs-issues/issues/187

Signed-off-by: Rui Cao <rcao@vmware.com>