### PR TITLE
Port patches to windows: "conntrack: Fix conntrack new state"

### DIFF
--- a/datapath-windows/ovsext/Conntrack-other.c
+++ b/datapath-windows/ovsext/Conntrack-other.c
@@ -49,17 +49,19 @@ OvsConntrackUpdateOtherEntry(OVS_CT_ENTRY *conn_,
 {
     ASSERT(conn_);
     struct conn_other *conn = OvsCastConntrackEntryToOtherEntry(conn_);
+    enum CT_UPDATE_RES ret = CT_UPDATE_VALID;
 
     if (reply && conn->state != OTHERS_BIDIR) {
         conn->state = OTHERS_BIDIR;
     } else if (conn->state == OTHERS_FIRST) {
         conn->state = OTHERS_MULTIPLE;
+        ret = CT_UPDATE_VALID_NEW;
     }
 
     OvsConntrackUpdateExpiration(&conn->up, now,
                                  other_timeouts[conn->state]);
 
-    return CT_UPDATE_VALID;
+    return ret;
 }
 
 OVS_CT_ENTRY *

--- a/datapath-windows/ovsext/Conntrack.c
+++ b/datapath-windows/ovsext/Conntrack.c
@@ -753,6 +753,9 @@ OvsProcessConntrackEntry(OvsForwardingContext *fwdCtx,
                 return NULL;
             }
             break;
+        case CT_UPDATE_VALID_NEW:
+            state |= OVS_CS_F_NEW;
+            break;
         }
     }
     if (entry) {

--- a/datapath-windows/ovsext/Conntrack.h
+++ b/datapath-windows/ovsext/Conntrack.h
@@ -56,6 +56,7 @@ typedef enum CT_UPDATE_RES {
     CT_UPDATE_INVALID,
     CT_UPDATE_VALID,
     CT_UPDATE_NEW,
+    CT_UPDATE_VALID_NEW,
 } CT_UPDATE_RES;
 
 /* Metadata mark for masked write to conntrack mark */


### PR DESCRIPTION
Port following commits to windows driver to fix the TCP conntrack new state issue on windows:
- a867c010ee9183885ee9d3eb76a0005c075c4d2e
- ac23d20fc90da3b1c9b2117d1e22102e99fba006
@YiHungWei
Fixes https://github.com/openvswitch/ovs-issues/issues/188