### PR TITLE
Additional parameters for physical DPDK ports

### DIFF
--- a/rhel/etc_sysconfig_network-scripts_ifup-ovs
+++ b/rhel/etc_sysconfig_network-scripts_ifup-ovs
@@ -171,7 +171,7 @@ case "$TYPE" in
                 ovs-vsctl -t ${TIMEOUT} \
                         -- --if-exists del-port "$OVS_BRIDGE" "$DEVICE" \
                         -- add-port "$OVS_BRIDGE" "$DEVICE" $OVS_OPTIONS \
-                        -- set Interface "$DEVICE" type=dpdk ${OVS_EXTRA+-- $OVS_EXTRA}
+                        -- set Interface "$DEVICE" type=dpdk options:dpdk-devargs=$OVS_PCI ${OVS_EXTRA+-- $OVS_EXTRA}
                 BRIDGE_MAC=$(get_hwaddr $OVS_BRIDGE)
                 # The bridge may change its MAC to be the lower one among all its
                 # ports. If that happens, bridge configuration (e.g. routes) will


### PR DESCRIPTION
Hello developers,

**Problem**: Right now, only physical DPDK ports beginning with 'dpdk' prefix are supported in the Red Hat network scripts.
However, openvswitch no longer supports this naming pattern. See this error message from ovs 2.11.1:
```shell
error: "'dpdk-eth1-1' is missing 'options:dpdk-devargs'. The old 'dpdk<port_id>' names are not supported"
```

The current way of adding a physical DPDK port is:
```shell
ovs-vsctl add-port <br-name> <port-name> \
 -- set Interface <port-name> type=dpdk options:dpdk-devargs=<PCI_address> 
```
[See OvS doc](http://docs.openvswitch.org/en/latest/topics/dpdk/phy/)

**Suggestion**: Include a new variable specifying the pci address of a physical DPDK device.
