### PR TITLE
releases doc: Meter action does not really work in upstream Linux kernels older than 4.18

### DIFF
--- a/Documentation/faq/releases.rst
+++ b/Documentation/faq/releases.rst
@@ -143,7 +143,7 @@ Q: Are all features available with all datapaths?
     Set action                      YES            1.0          1.0    PARTIAL
     NIC Bonding                     YES            1.0          1.0      YES
     Multiple VTEPs                  YES            1.10         1.10     YES
-    Meter action                    4.15           2.10         2.7      NO
+    Meter action                    4.18           2.10         2.7      NO
     check_pkt_len action            5.2            2.12         2.12     NO
     ========================== ============== ============== ========= =======
 


### PR DESCRIPTION
Since 92d0d515d6 Open vSwitch disables meter action in linux kernel
path for 4.15, 4.16 and 4.17 but docs says Meter action is supported in
4.15 which can be misleading.

Since Ubuntu 18.04 kernel is 4.15, this can confuse many users.