### PR TITLE
netdev-linux.c: Fix NULL deref reported by Coverity.

### DIFF
--- a/lib/netdev-linux.c
+++ b/lib/netdev-linux.c
@@ -634,7 +634,9 @@ netdev_linux_notify_sock(void)
                 }
             }
         }
-        nl_sock_listen_all_nsid(sock, true);
+	if (sock != NULL) {
+            nl_sock_listen_all_nsid(sock, true);
+	}
         ovsthread_once_done(&once);
     }
 


### PR DESCRIPTION
When sock is NULL, calling nl_sock_listen_all_nsid triggers NULL deref.