### PR TITLE
Fix ovs-monitor-ipsec support for strongSwan >= version 5.7.0

### DIFF
--- a/ipsec/ovs-monitor-ipsec.in
+++ b/ipsec/ovs-monitor-ipsec.in
@@ -145,10 +145,18 @@ class StrongSwanHelper(object):
     """This class does StrongSwan specific configurations."""
 
     STRONGSWAN_CONF = """%s
-charon.plugins.kernel-netlink.set_proto_port_transport_sa = yes
-charon.plugins.kernel-netlink.xfrm_ack_expires = 10
-charon.load_modular = yes
-charon.plugins.gcm.load = yes
+charon {
+    plugins {
+       kernel-netlink {
+           set_proto_port_transport_sa = yes
+           xfrm_ack_expires = 10
+        }
+        gcm {
+            load = yes
+        }
+    }
+    load_modular = yes
+}
 """ % (FILE_HEADER)
 
     CONF_HEADER = """%s


### PR DESCRIPTION
Starting from version 5.7.0, strongSwan no more supports specifying a
configuration parameter with the path delimited by dots in a
configuration file. This commit fixes the strongSwan configuration
parameters that ovs-monitor-ipsec writes, to comply with the new
strongSwan format.