### PR TITLE
Fix buffer overflow while parsing lldp packets

### DIFF
--- a/lib/lldp/lldp.c
+++ b/lib/lldp/lldp.c
@@ -482,6 +482,11 @@ lldp_decode(struct lldpd *cfg OVS_UNUSED, char *frame, int s,
             CHECK_TLV_SIZE(1, "Management address");
             addr_str_length = PEEK_UINT8;
             CHECK_TLV_SIZE(1 + addr_str_length, "Management address");
+            if (addr_str_length >= 32) {
+                VLOG_WARN("too long management address received on %s",
+                          hardware->h_ifname);
+                goto malformed;
+            }
             PEEK_BYTES(addr_str_buffer, addr_str_length);
             addr_length = addr_str_length - 1;
             addr_family = addr_str_buffer[0];


### PR DESCRIPTION
```
u_int8_t addr_str_length, addr_str_buffer[32];
```

```
        case LLDP_TLV_MGMT_ADDR:
            CHECK_TLV_SIZE(1, "Management address");
            addr_str_length = PEEK_UINT8;
            CHECK_TLV_SIZE(1 + addr_str_length, "Management address");
            PEEK_BYTES(addr_str_buffer, addr_str_length);
```

This pull request checks the size of `addr_str_length` and if the management address is larger than 32 bytes.