### PR TITLE
LLDP: PEEK_DISCARD_UINT32 should discard 4 bytes

### DIFF
--- a/lib/lldp/lldp.c
+++ b/lib/lldp/lldp.c
@@ -59,7 +59,7 @@ VLOG_DEFINE_THIS_MODULE(lldp);
     } while (0)
 #define PEEK_DISCARD_UINT8 PEEK_DISCARD(1)
 #define PEEK_DISCARD_UINT16 PEEK_DISCARD(2)
-#define PEEK_DISCARD_UINT32 PEEK_DISCARD(3)
+#define PEEK_DISCARD_UINT32 PEEK_DISCARD(4)
 #define PEEK_CMP(value, bytes) \
      (length -= (bytes),       \
      pos += (bytes),           \


### PR DESCRIPTION
Wrong amount of bytes discarded when using `PEEK_DISCARD_UINT32`.
Currently this macro is unused.