### PR TITLE
Issue Description : $pkidir already exists and --force not specified. --force will cause $pkidir to be permanently deleted.

### DIFF
--- a/utilities/ovs-pki.in
+++ b/utilities/ovs-pki.in
@@ -219,6 +219,10 @@ if test "$command" = "init"; then
         exit 1
     fi
 
+    if test "$force" = "yes"; then
+       rm -rf "$pkidir"
+    fi
+
     if test ! -d "$pkidir"; then
         mkdir -p "$pkidir"
     fi


### PR DESCRIPTION
…196 - ovs-pki init --force is not regenerating the ca.cnf file for the switchca and controllerca.

Root Cause : ovs-pki init --force option is not removing the pki directory instead it touches the pki directory with already exisiting files.

FIX : When ovs-pki init with --force option is specified remove the pki directory and regenerate the switchca and controllerca folder with ca.cnf files.