### PR TITLE
stt: fix dst_entry use-after-free in rcv_list for GSO skb

### DIFF
--- a/datapath/linux/compat/stt.c
+++ b/datapath/linux/compat/stt.c
@@ -1397,10 +1397,8 @@ static void rcv_list(struct net_device *dev, struct sk_buff *skb,
 	do {
 		next = skb->next;
 		skb->next = NULL;
-		if (next) {
+		if (next)
 			ovs_dst_hold((struct dst_entry *)tun_dst);
-			ovs_skb_dst_set(next, (struct dst_entry *)tun_dst);
-		}
 		ovs_ip_tunnel_rcv(dev, skb, tun_dst);
 	} while ((skb = next));
 }


### PR DESCRIPTION
rcv_list assigns next->dst which is later released in skb_scrub_packet
and then assigns the same dst_entry again in ovs_ip_tunnel_rcv, but it
was freed already.

Signed-off-by: Vitaly Mayatskikh <vmayatskikh@digitalocean.com>