### PR TITLE
LLDP: fix wrong "const char*" issue which leads to the chassis descriptor always as the same

### DIFF
--- a/lib/ovs-lldp.c
+++ b/lib/ovs-lldp.c
@@ -203,7 +203,7 @@ aa_print_element_status_port(struct ds *ds, struct lldpd_hardware *hw)
                    &system_id_null,
                    sizeof port->p_element.system_id)) {
             const char *none_str = "<None>";
-            const char *descr = NULL;
+            char *descr = NULL;
             char *id = NULL;
             char *system;
 


### PR DESCRIPTION
fix wrong "const char*" issue which leads to the chassis descriptor always as the same