### PR TITLE
Python: Support open tcp socket with domain name

### DIFF
--- a/python/ovs/socket_util.py
+++ b/python/ovs/socket_util.py
@@ -219,18 +219,16 @@ def inet_parse_active(target, default_port):
         host_name = address[0]
     if not host_name:
         raise ValueError("%s: bad peer name format" % target)
+    try:
+        # If host_name is domain name convert it to ip address string
+        host_name = socket.gethostbyname(host_name)
+    except socket.gaierror as e:
+        return get_exception_errno(e), None
     return (host_name, port)
 
 
 def inet_open_active(style, target, default_port, dscp):
     address = inet_parse_active(target, default_port)
-    try:
-        # If address is domain name convert it to ip address string
-        address_list = list(address)
-        address_list[0] = socket.gethostbyname(address_list[0])
-        address = tuple(address_list)
-    except socket.gaierror as e:
-        return get_exception_errno(e), None
     try:
         is_addr_inet = is_valid_ipv4_address(address[0])
         if is_addr_inet:

--- a/python/ovs/socket_util.py
+++ b/python/ovs/socket_util.py
@@ -223,7 +223,7 @@ def inet_parse_active(target, default_port):
         # If host_name is domain name convert it to ip address string
         host_name = socket.gethostbyname(host_name)
     except socket.gaierror as e:
-        return get_exception_errno(e), None
+        raise e
     return (host_name, port)
 
 

--- a/python/ovs/socket_util.py
+++ b/python/ovs/socket_util.py
@@ -225,6 +225,14 @@ def inet_parse_active(target, default_port):
 def inet_open_active(style, target, default_port, dscp):
     address = inet_parse_active(target, default_port)
     try:
+        # If address is domain name convert it to ip address string
+        address_list = list(address)
+        address_list[0] = socket.gethostbyname(address_list[0])
+        address = tuple(address_list)
+    except socket.gaierror as e:
+        return get_exception_errno(e), None
+    address = inet_parse_active(target, default_port)
+    try:
         is_addr_inet = is_valid_ipv4_address(address[0])
         if is_addr_inet:
             sock = socket.socket(socket.AF_INET, style, 0)

--- a/python/ovs/socket_util.py
+++ b/python/ovs/socket_util.py
@@ -231,7 +231,6 @@ def inet_open_active(style, target, default_port, dscp):
         address = tuple(address_list)
     except socket.gaierror as e:
         return get_exception_errno(e), None
-    address = inet_parse_active(target, default_port)
     try:
         is_addr_inet = is_valid_ipv4_address(address[0])
         if is_addr_inet:


### PR DESCRIPTION
When try to connect to a remote tcp socket, remote address don't
support use domain name.
Fixed it by reslove it in ovs.socket_util.inet_open_active.