### PR TITLE
RFC - util: fallback when locked memory allocation fails

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -144,7 +144,9 @@ void ctl_timeout_setup(unsigned int secs);
 void ovs_print_version(uint8_t min_ofp, uint8_t max_ofp);
 
 void set_memory_locked(void);
+void set_memory_unlocked(void);
 bool memory_locked(void);
+bool retry_after_out_of_memory(void);
 
 OVS_NO_RETURN void out_of_memory(void);
 void *xmalloc(size_t) MALLOC_LIKE;


### PR DESCRIPTION
Normally when OVS runs on a server the effective system limit for
locked memory is unlimited as the ovs-vswitchd runs as the root
user in the root namespace of the server.

When OVS is run in a non-priviledged container a system limit will
apply and its possible that this limit will be reached during
normal operation.

If this occurs unlock all memory and re-attempt (re)allocation of
memory rather than fail and abort.

If this subsequent attempt also fails abort the process as before.

Signed-off-by: James Page <james.page@ubuntu.com>