### PR TITLE
debian: Add configure option to debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -30,7 +30,7 @@ override_dh_autoreconf:
 	dh_autoreconf $(DH_AS_NEEDED)
 
 override_dh_auto_configure:
-	dh_auto_configure -- --enable-ssl --enable-shared $(DATAPATH_CONFIGURE_OPTS)
+	dh_auto_configure -- --enable-ssl --enable-shared $(DATAPATH_CONFIGURE_OPTS) $(EXTRA_CONFIGURE_OPTS)
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))


### PR DESCRIPTION
Before this fix, in order to build with jemalloc,
I had to hijack DATAPATH_CONFIGURE_OPTS:
debian/rules -e DATAPATH_CONFIGURE_OPTS="LIBS=-ljemalloc"
Now it is possible to:
debian/rules -e EXTRA_CONFIGURE_OPTS="LIBS=-ljemalloc"

Signed-off-by: Shahar Klein <sklein@nvidia.com>