### PR TITLE
make: don't prompt during build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -168,7 +168,7 @@ SUFFIXES += .in
 	@if head -n 1 $@.tmp | grep '#!' > /dev/null; then \
 	  chmod +x $@.tmp; \
 	fi
-	$(AM_V_at) mv $@.tmp $@
+	$(AM_V_at) mv -f $@.tmp $@
 
 SUFFIXES += .xml
 %: %.xml

--- a/lib/automake.mk
+++ b/lib/automake.mk
@@ -590,7 +590,7 @@ lib/dirs.c: lib/dirs.c.in Makefile
 		-e 's,[@]sysconfdir[@],"$(sysconfdir)",g' \
 		-e 's,[@]pkgdatadir[@],"$(pkgdatadir)",g') \
 	     > lib/dirs.c.tmp && \
-	mv lib/dirs.c.tmp lib/dirs.c
+	mv -f lib/dirs.c.tmp lib/dirs.c
 
 lib/meta-flow.inc: $(srcdir)/build-aux/extract-ofp-fields include/openvswitch/meta-flow.h
 	$(AM_V_GEN)$(run_python) $< meta-flow $(srcdir)/include/openvswitch/meta-flow.h > $@.tmp


### PR DESCRIPTION
when I rebuild code I was getting a prompt caused when the target of a move file already exists with restricted permissions. By adding the `mv -f` flag I eliminate the prompt.

the sequence I ran (on an ubuntu 20.0.4 host):

```
./boot.sh
./configure --with-linux=/lib/modules/$(uname -r)/build
make
```

to reproduce the issue I am addressing run:

```
make
```
