### PR TITLE
Add a check that either the --all or records argument provided to destroy command

### DIFF
--- a/lib/db-ctl-base.c
+++ b/lib/db-ctl-base.c
@@ -1823,6 +1823,11 @@ cmd_destroy(struct ctl_context *ctx)
         return;
     }
 
+    if (!delete_all && ctx->argc == 2) {
+        VLOG_WARN("either --all or records argument should be specified");
+        return;
+    }
+
     if (delete_all) {
         const struct ovsdb_idl_row *row;
         const struct ovsdb_idl_row *next_row;

--- a/tests/ovs-vsctl.at
+++ b/tests/ovs-vsctl.at
@@ -1484,6 +1484,11 @@ AT_CHECK([RUN_OVS_VSCTL(
 qos                 : []
 ]])
 AT_CHECK([RUN_OVS_VSCTL(
+   [ destroy Qos])], [0],[], [stderr])
+AT_CHECK([sed "s/^.*|WARN|//" < stderr], [0],
+[[either --all or records argument should be specified
+]]) 
+AT_CHECK([RUN_OVS_VSCTL(
    [--all destroy Qos])])
 AT_CHECK([RUN_OVS_VSCTL(
    [-- list Qos])])


### PR DESCRIPTION
`ovn-nbctl` or `ovn-sbctl` CLI utilities allow destroying the entire table or some records from the given table.
However, either the `--all` option or the deleted records should be provided. 
This patch adds the test.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>