### PR TITLE
utilities: disable mlockall in containers

### DIFF
--- a/utilities/ovs-ctl.in
+++ b/utilities/ovs-ctl.in
@@ -212,8 +212,11 @@ do_start_forwarding () {
         # Start ovs-vswitchd.
         set ovs-vswitchd unix:"$DB_SOCK"
         set "$@" -vconsole:emer -vsyslog:err -vfile:info
-        if test X"$MLOCKALL" != Xno; then
-            set "$@" --mlockall
+        # Disable mlockall in containers
+        if ! in_container; then
+            if test X"$MLOCKALL" != Xno; then
+                set "$@" --mlockall
+            fi
         fi
         if test X"$SELF_CONFINEMENT" = Xno; then
             set "$@" --no-self-confinement

--- a/utilities/ovs-lib.in
+++ b/utilities/ovs-lib.in
@@ -702,3 +702,11 @@ restart () {
     flow_restore_complete
     add_managers
 }
+
+in_container () {
+    if [ -x /usr/bin/systemd-detect-virt ]; then
+        systemd-detect-virt -c -q
+        return $?
+    fi
+    return 1
+}


### PR DESCRIPTION
When OVS is run in a non-priviledged container a system limit will
apply and its possible that this limit will be reached during
normal operation.

To avoid this situation disable all memory locking when OVS is
executed within a container.

Signed-off-by: James Page <james.page@ubuntu.com>