### PR TITLE
fix coredump when using "ovs-ofctl add-groups"

### DIFF
--- a/utilities/ovs-ofctl.c
+++ b/utilities/ovs-ofctl.c
@@ -5051,7 +5051,7 @@ static const struct ovs_cmdl_command all_commands[] = {
     { "add-group", "switch group",
       1, 2, ofctl_add_group, OVS_RW },
     { "add-groups", "switch file",
-      1, 2, ofctl_add_groups, OVS_RW },
+      2, 2, ofctl_add_groups, OVS_RW },
     { "mod-group", "switch group",
       1, 2, ofctl_mod_group, OVS_RW },
     { "del-groups", "switch [group]",


### PR DESCRIPTION
desc: When using ovs-ofctl add-groups with only "switch" argument, a
coredump is generated. The main reason is that the command "ovs-ofctl
add-groups" need two arguments but the limitation of min-args of this
command is set to 1.

Signed-off-by: Wang Yibo <bobxxwang@126.com>