### PR TITLE
openflow: allow to configure ofp_desc fields on bridge other_config

### DIFF
--- a/ofproto/ofproto.c
+++ b/ofproto/ofproto.c
@@ -797,6 +797,27 @@ ofproto_set_threads(int n_handlers_, int n_revalidators_)
 }
 
 void
+ofproto_set_mfr_desc(struct ofproto *p, const char *mfr_desc)
+{
+    free(p->mfr_desc);
+    p->mfr_desc = nullable_xstrdup(mfr_desc);
+}
+
+void
+ofproto_set_hw_desc(struct ofproto *p, const char* hw_desc)
+{
+    free(p->hw_desc);
+    p->hw_desc = nullable_xstrdup(hw_desc);
+}
+
+void
+ofproto_set_sw_desc(struct ofproto *p, const char* sw_desc)
+{
+    free(p->sw_desc);
+    p->sw_desc = nullable_xstrdup(sw_desc);
+}
+
+void
 ofproto_set_dp_desc(struct ofproto *p, const char *dp_desc)
 {
     free(p->dp_desc);

--- a/ofproto/ofproto.h
+++ b/ofproto/ofproto.h
@@ -350,6 +350,9 @@ int ofproto_port_set_mcast_snooping(struct ofproto *ofproto, void *aux,
 void ofproto_set_threads(int n_handlers, int n_revalidators);
 void ofproto_type_set_config(const char *type,
                              const struct smap *other_config);
+void ofproto_set_mfr_desc(struct ofproto*, const char *mfr_desc);
+void ofproto_set_hw_desc(struct ofproto*, const char *hw_desc);
+void ofproto_set_sw_desc(struct ofproto*, const char *sw_desc);
 void ofproto_set_dp_desc(struct ofproto *, const char *dp_desc);
 void ofproto_set_serial_desc(struct ofproto *p, const char *serial_desc);
 int ofproto_set_snoops(struct ofproto *, const struct sset *snoops);

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -287,8 +287,7 @@ static void bridge_configure_sflow(struct bridge *, int *sflow_bridge_number);
 static void bridge_configure_ipfix(struct bridge *);
 static void bridge_configure_spanning_tree(struct bridge *);
 static void bridge_configure_tables(struct bridge *);
-static void bridge_configure_dp_desc(struct bridge *);
-static void bridge_configure_serial_desc(struct bridge *);
+static void bridge_configure_ofp_desc(struct bridge *);
 static void bridge_configure_aa(struct bridge *);
 static void bridge_aa_refresh_queued(struct bridge *);
 static bool bridge_aa_need_refresh(struct bridge *);
@@ -942,8 +941,7 @@ bridge_reconfigure(const struct ovsrec_open_vswitch *ovs_cfg)
         bridge_configure_ipfix(br);
         bridge_configure_spanning_tree(br);
         bridge_configure_tables(br);
-        bridge_configure_dp_desc(br);
-        bridge_configure_serial_desc(br);
+        bridge_configure_ofp_desc(br);
         bridge_configure_aa(br);
     }
     free(managers);
@@ -4123,17 +4121,23 @@ bridge_configure_tables(struct bridge *br)
 }
 
 static void
-bridge_configure_dp_desc(struct bridge *br)
+bridge_configure_ofp_desc(struct bridge *br)
 {
-    ofproto_set_dp_desc(br->ofproto,
-                        smap_get(&br->cfg->other_config, "dp-desc"));
-}
-
-static void
-bridge_configure_serial_desc(struct bridge *br)
-{
+    // Manufacturer description
+    ofproto_set_mfr_desc(br->ofproto,
+                         smap_get(&br->cfg->other_config, "mfr-desc"));
+    // Hardware description
+    ofproto_set_hw_desc(br->ofproto,
+                        smap_get(&br->cfg->other_config, "hw-desc"));
+    // Software description
+    ofproto_set_sw_desc(br->ofproto,
+                        smap_get(&br->cfg->other_config, "sw-desc"));
+    // Serial number
     ofproto_set_serial_desc(br->ofproto,
                         smap_get(&br->cfg->other_config, "dp-sn"));
+    // DP description
+    ofproto_set_dp_desc(br->ofproto,
+                        smap_get(&br->cfg->other_config, "dp-desc"));
 }
 
 static struct aa_mapping *

--- a/vswitchd/vswitch.xml
+++ b/vswitchd/vswitch.xml
@@ -1309,6 +1309,27 @@
         prefix or be exactly 16 hex digits long.  May not be all-zero.
       </column>
 
+      <column name="other_config" key="mfr-desc">
+        Manufacturer description. Defaults to "Nicira, Inc.".
+        The value is returned by the switch as a part of reply to OFPMP_DESC
+        request (ofp_desc). The OpenFlow specification (e.g. 1.3.5) describes
+        the ofp_desc structure to contaion "NULL terminated ASCII strings".
+      </column>
+
+      <column name="other_config" key="hw-desc">
+        Hardware description. Defaults to "Open vSwitch".
+        The value is returned by the switch as a part of reply to OFPMP_DESC
+        request (ofp_desc). The OpenFlow specification (e.g. 1.3.5) describes
+        the ofp_desc structure to contaion "NULL terminated ASCII strings".
+      </column>
+
+      <column name="other_config" key="sw-desc">
+        Software description. Defaults to the current Open vSwitch version.
+        The value is returned by the switch as a part of reply to OFPMP_DESC
+        request (ofp_desc). The OpenFlow specification (e.g. 1.3.5) describes
+        the ofp_desc structure to contaion "NULL terminated ASCII strings".
+      </column>
+
       <column name="other_config" key="dp-desc">
         Human readable description of datapath.  It is a maximum 256
         byte-long free-form string to describe the datapath for


### PR DESCRIPTION
## Description

This pull request allows the user to configure the missing (currently static/forced) fields returned by the switch as a part of reply to a `OFPMP_DESC` request (ofp_desc), namely:

- **mfr_desc**: Manufacturer description (currently always Nicira, Inc.)
- **hw_desc**: Hardware description (currently always "Open vSwitch")
- **sw_desc**: Software description (currently always the version of OVS)

on the other-config of the Bridge table. 

serial_desc and dp_desc were already available, so I decided to group all of them on a single function (`bridge_configure_ofp_desc`) for the sake of simplicity.

## Motivation

SDN controllers such as [ONOS](https://github.com/opennetworkinglab/onos) make use of the information provided from the switch in the reply to `OFPMP_DESC` to load SDN controller drivers that define and control the pipeline (i.e. the sequence of tables and what match fields/actions are available in certain tables). Most of these drivers (if not all) are compatible with openvswitch. Some of them, for instance [ofdpa-ovs](https://github.com/opennetworkinglab/onos/blob/2b4de873e4033b7973b399d25cb8828a73bc2e24/drivers/default/src/main/resources/onos-drivers.xml#L162-L167) are even designed to emulate physical pipelines (ofdpa) on top of the OVS dataplane.
It'd be nice that we could configure those fields so that the appropriate driver is loaded automatically when ovs attempts to connect to the controller. 

## Tests

This was runtime tested using the latest ONOS version. In OVS the following commands were executed:

```
ovs-vsctl add-br br0
ovs-vsctl set bridge br0 other_config:mfr-desc=ONF
ovs-vsctl set bridge br0 other_config:hw-desc="OFDPA OVS"
ovs-vsctl set bridge br0 other_config:sw-desc="OFDPA OVS"
ovs-vsctl set-controller br0 tcp:xxx.xxx.xxx.xxx:6633
```

The controller automatically loaded the ovs-ofdpa driver instead of the default one.

Please kindly provide feedback
Regards
