### PR TITLE
Fix: Update control file for debian package.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends: graphviz,
                bzip2,
                debhelper (>= 8),
                dh-autoreconf,
+               dh-python,
                libssl-dev,
                libtool,
                openssl,
@@ -138,7 +139,8 @@ Description: Open vSwitch public key infrastructure dependency package
 
 Package: openvswitch-testcontroller
 Architecture: linux-any
-Depends: openvswitch-common (= ${binary:Version}),
+Depends: lsb-base,
+         openvswitch-common (= ${binary:Version}),
          openvswitch-pki (= ${source:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
@@ -247,6 +249,7 @@ Description: Open vSwitch development package
 Package: openvswitch-ipsec
 Architecture: linux-any
 Depends: iproute2,
+         lsb-base,
          openvswitch-common (= ${binary:Version}),
          openvswitch-switch (= ${binary:Version}),
          python3,


### PR DESCRIPTION
When make debian packages there are some lintian errors.Update Build-depends and Depends to fix folling errors:
E: openvswitch source: missing-build-dependency-for-dh-addon python3 => dh-python
E: openvswitch-ipsec: init.d-script-needs-depends-on-lsb-base etc/init.d/openvswitch-ipsec (line 42)
E: openvswitch-testcontroller: init.d-script-needs-depends-on-lsb-base etc/init.d/openvswitch-testcontroller (line 45)