### PR TITLE
Windows build in github action

### DIFF
--- a/.ci/windows-build.sh
+++ b/.ci/windows-build.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -o errexit
+set -x
+
+CFLAGS_FOR_OVS="-g -O2"
+EXTRA_OPTS=""
+
+
+function configure_ovs()
+{
+    ./boot.sh
+    ./configure CC=./build-aux/cccl LD="`which link`" \
+    --with-pthread="./PTHREADS-BUILT" \
+    LIBS="-lws2_32 -lShlwapi -liphlpapi -lwbemuuid -lole32 -loleaut32" \
+    CFLAGS="${CFLAGS_FOR_OVS}" $* || { cat config.log; exit 1; }
+}
+
+function build_ovs()
+{
+    configure_ovs $OPTS
+    make -j4 || { cat config.log; exit 1; }
+
+}
+
+save_OPTS="${OPTS} $*"
+OPTS="${EXTRA_OPTS} ${save_OPTS}"
+
+if [ "$TESTSUITE" ]; then
+    # 'distcheck' will reconfigure with required options.
+    configure_ovs
+
+    export DISTCHECK_CONFIGURE_FLAGS="$OPTS"
+    if ! make distcheck -j4 CFLAGS="${CFLAGS_FOR_OVS}" \
+         TESTSUITEFLAGS=-j4 RECHECK=yes; then
+        # testsuite.log is necessary for debugging.
+        cat */_build/sub/tests/testsuite.log
+        exit 1
+    fi
+else
+    EXTRA_OPTS="${save_EXTRA_OPTS}"
+    OPTS="${EXTRA_OPTS} ${save_OPTS}"
+    build_ovs
+    make distclean
+fi
+
+exit 0

--- a/.ci/windows-build.sh
+++ b/.ci/windows-build.sh
@@ -4,44 +4,27 @@ set -o errexit
 set -x
 
 CFLAGS_FOR_OVS="-g -O2"
-EXTRA_OPTS=""
-
+EXTRA_OPTS="--with-pthread=`realpath ./PTHREADS-BUILT | xargs cygpath -m`"
 
 function configure_ovs()
 {
     ./boot.sh
-    ./configure CC=./build-aux/cccl LD="`which link`" \
-    --with-pthread="./PTHREADS-BUILT" \
+    ./configure CC="./build-aux/cccl" LD="`which link`" \
     LIBS="-lws2_32 -lShlwapi -liphlpapi -lwbemuuid -lole32 -loleaut32" \
     CFLAGS="${CFLAGS_FOR_OVS}" $* || { cat config.log; exit 1; }
 }
 
-function build_ovs()
-{
-    configure_ovs $OPTS
-    make -j4 || { cat config.log; exit 1; }
 
-}
-
-save_OPTS="${OPTS} $*"
-OPTS="${EXTRA_OPTS} ${save_OPTS}"
+OPTS="${EXTRA_OPTS} ${OPTS} $*"
+configure_ovs $OPTS
+make -j4 || { cat config.log; exit 1; }
 
 if [ "$TESTSUITE" ]; then
-    # 'distcheck' will reconfigure with required options.
-    configure_ovs
-
-    export DISTCHECK_CONFIGURE_FLAGS="$OPTS"
-    if ! make distcheck -j4 CFLAGS="${CFLAGS_FOR_OVS}" \
-         TESTSUITEFLAGS=-j4 RECHECK=yes; then
+    if ! make check TESTSUITEFLAGS=-j8 RECHECK=yes; then
         # testsuite.log is necessary for debugging.
-        cat */_build/sub/tests/testsuite.log
+        cat ./tests/testsuite.log
         exit 1
     fi
-else
-    EXTRA_OPTS="${save_EXTRA_OPTS}"
-    OPTS="${EXTRA_OPTS} ${save_OPTS}"
-    build_ovs
-    make distclean
 fi
 
 exit 0

--- a/.ci/windows-prepare.sh
+++ b/.ci/windows-prepare.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ev
+
+# clone and build pthreads4w
+git clone https://git.code.sf.net/p/pthreads4w/code pthreads4w-code
+cd pthreads4w-code
+nmake all install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -243,10 +243,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - opts: --disable-ssl --with-vstudiotarget=Debug --with-vstudiotargetver=Win8        
-          - opts: --disable-ssl --with-vstudiotarget=Debug --with-vstudiotargetver=Win8.1            
+          # run only one job for windows, as more than one be enough currently to verify
+          # PRs
+          # tests are not enabled as they take very long and a lot of them will fail to          
           - opts: --disable-ssl --with-vstudiotarget=Debug --with-vstudiotargetver=Win10
-            testsuite: 1-5
+          
     defaults:
       run:
          shell: msys2 {0}         
@@ -292,6 +293,7 @@ jobs:
           ln -s "$pythonLocation\python" /ucrt64/bin/python3      
       - name: prepare
         run:  | 
+          [[ -f /usr/bin/link ]] && mv /usr/bin/link /usr/bin/link_off
           source ~/.visualstudio.sh 
           ./.ci/windows-prepare.sh
       - name: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -228,3 +228,81 @@ jobs:
       with:
         name: logs-osx-clang---disable-ssl
         path: config.log
+
+  build-windows:
+    name: windows ${{ join(matrix.*, ' ') }}
+    env:
+      OPTS: --prefix=C:/openvswitch/usr --localstatedir=C:/openvswitch/var --sysconfdir=C:/openvswitch/etc ${{ matrix.opts }}
+      TESTSUITE: ${{ matrix.testsuite }}
+    
+    # linking on latest VS 2019 don't work, most propably due to a VS 2019 issue since VS 16.10
+    runs-on: windows-2016
+    timeout-minutes: 60
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - opts: --disable-ssl --with-vstudiotarget=Debug --with-vstudiotargetver=Win8        
+          - opts: --disable-ssl --with-vstudiotarget=Debug --with-vstudiotargetver=Win8.1            
+          - opts: --disable-ssl --with-vstudiotarget=Debug --with-vstudiotargetver=Win10
+            testsuite: 1-5
+    defaults:
+      run:
+         shell: msys2 {0}         
+         
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install msys 
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: base-devel git mingw-w64-ucrt-x86_64-toolchain
+      - name: set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'  
+
+      # pypiwin32 has to be installed with a Windows python version therefore
+      # this step will configure python first on Windows and exports
+      # its location for MSYS bash.  
+      - name: configure python in Windows cmdline
+        shell: cmd
+        run: |
+            python -m pip install --upgrade pip
+            pip install pypiwin32
+            echo export pythonLocation="%pythonLocation%" > %RUNNER_TEMP%\msys\msys64\home\%USERNAME%\.pythonenv.sh
+            echo export PYTHONPATH="%pythonLocation%\Lib;%pythonLocation%\DLLs;%pythonLocation%\Lib\lib-tk" >> %RUNNER_TEMP%\msys\msys64\home\%USERNAME%\.pythonenv.sh
+            echo ".pythonenv.sh was generated in %RUNNER_TEMP%\msys\msys64\home\%USERNAME%"
+      - name: generate Visual Studio environment  
+        shell: cmd
+        run: |
+          powershell -c ./build-aux/envdiff.ps1          
+          @call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"          
+          powershell -c ./build-aux/envdiff.ps1 > %RUNNER_TEMP%\msys\msys64\home\%USERNAME%\.visualstudio.sh
+          echo ".visualstudio.sh was generated in %RUNNER_TEMP%\msys\msys64\home\%USERNAME%"
+      - name: configure python for MSYS 
+        run:  | 
+          source ~/.pythonenv.sh
+          echo "using python from path $pythonLocation"
+          mv /ucrt64/bin/python /ucrt64/bin/python_off
+          mv /ucrt64/bin/python3 /ucrt64/bin/python3_off          
+          ln -s "$pythonLocation\python" /ucrt64/bin/python3      
+      - name: prepare
+        run:  | 
+          source ~/.visualstudio.sh 
+          ./.ci/windows-prepare.sh
+      - name: build
+        run:  | 
+          source ~/.visualstudio.sh 
+          source ~/.pythonenv.sh
+          echo $PYTHONPATH
+          ./.ci/windows-build.sh
+      - name: upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-windows-msvc---disable-ssl
+          path: config.log

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -304,5 +304,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-windows-msvc---disable-ssl
+          name: logs-windows-${{ join(matrix.*, '-') }}
           path: config.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,8 @@ EXTRA_DIST = \
 	.ci/linux-prepare.sh \
 	.ci/osx-build.sh \
 	.ci/osx-prepare.sh \
+	.ci/windows-build.sh \
+	.ci/windows-prepare.sh \	
 	.cirrus.yml \
 	.github/workflows/build-and-test.yml \
 	.travis.yml \

--- a/build-aux/automake.mk
+++ b/build-aux/automake.mk
@@ -9,7 +9,8 @@ EXTRA_DIST += \
 	build-aux/sodepends.py \
 	build-aux/soexpand.py \
 	build-aux/text2c \
-	build-aux/xml2nroff
+	build-aux/xml2nroff \
+	build-aux/envdiff.ps1
 
 FLAKE8_PYFILES += \
     $(srcdir)/build-aux/xml2nroff \

--- a/build-aux/envdiff.ps1
+++ b/build-aux/envdiff.ps1
@@ -1,0 +1,44 @@
+# script to export  windows environment variables to bash shell
+# This is useful to create bash environments from vcvars64.bat
+# based on the solution from this article https://anadoxin.org/blog/bringing-visual-studio-compiler-into-msys2-environment.html/
+
+if((Test-Path "snapshot.env") -eq $false){
+
+    Get-ChildItem env: | Select-Object Key,Value | ConvertTo-Json | Set-Content "snapshot.env"
+    Write-Host "Stored snapshot.env"    
+    return
+}
+
+$snapshotEnv = Get-Content "snapshot.env" | ConvertFrom-Json
+
+foreach($e in Get-ChildItem env:){
+    if($e.Key -contains '/') {
+        # Sometimes Windows uses environment variables like i.e.
+        # ProgramFiles(x86)=c:\...
+        # but let's just skip this.
+        continue;
+    }
+    $key = $e.Key
+    $keyUpperCase = $e.Key.ToUpperInvariant()
+
+    if($keyUpperCase -eq "PATH") {
+        $path = $e.Value.Replace("c:", "/c").Replace("C:", "/c").Replace("\", "/").Replace(";", ":")
+        Write-Output "export PATH=""`$PATH:$path"""
+        continue
+    }
+    $valueEscaped = $e.value.replace("\", "\\");
+
+    $snapShotEntry = $snapshotEnv | Where-Object -Property Key -eq $key | Select-Object -First 1
+    
+    if($null -ne $snapShotEntry){
+        Write-Output "# debug: key=$keyUpperCase"
+        $oldValue = $snapShotEntry.Value
+        if($oldValue -ne $e.Value) {
+            Write-Output "export $key=""$valueEscaped"" #changed"
+        }    
+    }
+    else{
+        Write-Output "export $key=""$valueEscaped"" #new"
+
+    }
+}


### PR DESCRIPTION
This PR adds a github action to build ovs for windows. 

As discussed in https://github.com/openvswitch/ovs-issues/issues/209 use is currently limited as tests cannot be run for windows for a PR and PR requests are not the primary workflow to submit changes to ovs. 


