### PR TITLE
Separate the ssl config of ovsdb from openflow

### DIFF
--- a/ovsdb/ovsdb.h
+++ b/ovsdb/ovsdb.h
@@ -127,4 +127,7 @@ struct ovsdb_error *ovsdb_snapshot(struct ovsdb *, bool trim_memory)
 
 void ovsdb_replace(struct ovsdb *dst, struct ovsdb *src);
 
+#define OVSDB_SSL_OWNER "ovsdb"
+#define OVSDB_SSL_OWNER_COLUMN "owner"
+
 #endif /* ovsdb/ovsdb.h */

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -3315,7 +3315,14 @@ bridge_run(void)
      *
      * We do this before bridge_reconfigure() because that function might
      * initiate SSL connections and thus requires SSL to be configured. */
-    if (cfg && cfg->ssl) {
+    const struct ovsrec_ssl *ssl = NULL;
+    for (size_t i = 0; i < cfg->n_ssls; i++) {
+        if (strcmp(cfg->ssls[i]->owner, OPENFLOW_SSL_OWNER) == 0) {
+            ssl = cfg->ssls[i];
+            break;
+        }
+    }
+    if (ssl) {
         const struct ovsrec_ssl *ssl = cfg->ssl;
 
         stream_ssl_set_key_and_cert(ssl->private_key, ssl->certificate);

--- a/vswitchd/bridge.h
+++ b/vswitchd/bridge.h
@@ -28,4 +28,6 @@ void bridge_wait(void);
 
 void bridge_get_memory_usage(struct simap *usage);
 
+#define OPENFLOW_SSL_OWNER "openflow"
+
 #endif /* bridge.h */

--- a/vswitchd/vswitch.ovsschema
+++ b/vswitchd/vswitch.ovsschema
@@ -1,6 +1,6 @@
 {"name": "Open_vSwitch",
  "version": "8.3.0",
- "cksum": "3781850481 26690",
+ "cksum": "3090718775 26738",
  "tables": {
    "Open_vSwitch": {
      "columns": {
@@ -17,10 +17,10 @@
          "type": {"key": {"type": "uuid",
                           "refTable": "Manager"},
                   "min": 0, "max": "unlimited"}},
-       "ssl": {
+       "ssls": {
          "type": {"key": {"type": "uuid",
                           "refTable": "SSL"},
-                  "min": 0, "max": 1}},
+                  "min": 0, "max": 2}},
        "other_config": {
          "type": {"key": "string", "value": "string",
                   "min": 0, "max": "unlimited"}},
@@ -692,6 +692,8 @@
                   "min": 0, "max": "unlimited"}}}},
    "SSL": {
      "columns": {
+       "owner": {
+         "type": "string"},
        "private_key": {
          "type": "string"},
        "certificate": {
@@ -703,7 +705,7 @@
        "external_ids": {
          "type": {"key": "string", "value": "string",
                   "min": 0, "max": "unlimited"}}},
-     "maxRows": 1},
+     "maxRows": 2},
    "AutoAttach": {
      "columns": {
        "system_name": {

--- a/vswitchd/vswitch.xml
+++ b/vswitchd/vswitch.xml
@@ -63,7 +63,7 @@
         Set of bridges managed by the daemon.
       </column>
 
-      <column name="ssl">
+      <column name="ssls">
         SSL used globally by the daemon.
       </column>
 
@@ -6396,6 +6396,9 @@ ovs-vsctl add-port br0 p0 -- set Interface p0 type=patch options:peer=p1 \
 
   <table name="SSL">
     SSL configuration for an Open_vSwitch.
+    <column name="owner">
+      Name of the module that SSL configuration belongs to.
+    </column>
 
     <column name="private_key">
       Name of a PEM file containing the private key used as the switch's


### PR DESCRIPTION
modify the table of SSL to support 2 rows of SSL config belongs to ovsdb
and openflow for each
modify commands:
ovs-vsctl set-ssl
ovs-vsctl get-ssl
ovs-vsctl del-ssl
add a variable means the owner of components to support the SSL
management of ovsdb and openflow