### PR TITLE
vlog: fix startup fail when /var/log is full

### DIFF
--- a/include/openvswitch/vlog.h
+++ b/include/openvswitch/vlog.h
@@ -30,6 +30,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 #include <time.h>
+#include <errno.h>
 #include <openvswitch/compiler.h>
 #include <openvswitch/list.h>
 #include <openvswitch/thread.h>
@@ -261,6 +262,9 @@ void vlog_rate_limit(const struct vlog_module *, enum vlog_level,
             /* Exit if logfile explicitly given \
              * but cannot be opened. */         \
             if (err && optarg) {                \
+                if (err == ENOSPC) {            \
+                    break;                      \
+                }                               \
                 exit(EXIT_FAILURE);             \
             }                                   \
             break;                              \

--- a/lib/vlog.c
+++ b/lib/vlog.c
@@ -376,6 +376,12 @@ vlog_set_log_file__(char *new_log_file_name)
         if (new_log_fd < 0) {
             VLOG_WARN("failed to open %s for logging: %s",
                       new_log_file_name, ovs_strerror(errno));
+            ovs_mutex_lock(&log_file_mutex);
+            if ((log_file_name != NULL)) {
+                free(log_file_name);
+            }
+            log_file_name = xstrdup(new_log_file_name);
+            ovs_mutex_unlock(&log_file_mutex);
             free(new_log_file_name);
             return errno;
         }


### PR DESCRIPTION
vlog: fix startup fail when /var/log is full

When constrct /var/log full, ovsdb-server and ovs-vswitchd can not startup.
The main reasion is that OVS exit immediately after open log-file failed.

Signed-off-by: Shengwang Shi <shishengwang@huawei.com>