### PR TITLE
Fix python idl.Row.__str__ method

### DIFF
--- a/python/ovs/db/idl.py
+++ b/python/ovs/db/idl.py
@@ -1295,7 +1295,8 @@ class Row(object):
         return "{table}({data})".format(
             table=self._table.name,
             data=", ".join("{col}={val}".format(col=c, val=getattr(self, c))
-                           for c in sorted(self._table.columns)))
+                           for c in sorted(self._table.columns)
+                           if hasattr(self, c)))
 
     def _uuid_to_row(self, atom, base):
         if base.ref_table:


### PR DESCRIPTION
Fixes `idl.Row.__str__` to only add columns that exist on the object.  The `Row` object passed to the `updates` argument of `Idl.notify` only contains a subset of columns.  Printing that `Row` causes an `AttributeError` if there are any unchanged columns.

Signed-off-by: Christopher Aubut [christopher@aubut.me](mailto:christopher@aubut.me)