### PR TITLE
docs: afxdp: Fix CONFIG_HAVE_EBPF_JIT Kconfig option spelling.

### DIFF
--- a/Documentation/intro/install/afxdp.rst
+++ b/Documentation/intro/install/afxdp.rst
@@ -104,7 +104,7 @@ vSwitch with AF_XDP will require the following:
 
   * CONFIG_BPF_JIT=y (Performance)
 
-  * CONFIG_HAVE_BPF_JIT=y (Performance)
+  * CONFIG_HAVE_EBPF_JIT=y (Performance)
 
   * CONFIG_XDP_SOCKETS_DIAG=y (Debugging)
 


### PR DESCRIPTION
I'm assuming this is what was intended, as I'm unable to locate `CONFIG_HAVE_BPF_JIT` ("EBPF" vs "BPF").