### PR TITLE
Do not remove offloaded flows for running netdev

### DIFF
--- a/lib/dpif-netdev.c
+++ b/lib/dpif-netdev.c
@@ -3101,6 +3101,7 @@ dp_netdev_offload_flush(struct dp_netdev *dp,
     ovs_barrier_init(&barrier, 1 + netdev_offload_thread_nb());
 
     netdev = netdev_ref(port->netdev);
+    netdev->hw_info.is_deleting = true;
     dp_netdev_offload_flush_enqueue(dp, netdev, &barrier);
     ovs_barrier_block(&barrier);
     netdev_close(netdev);

--- a/lib/netdev-offload-dpdk.c
+++ b/lib/netdev-offload-dpdk.c
@@ -2546,7 +2546,9 @@ netdev_offload_dpdk_flow_flush(struct netdev *netdev)
         if (data->netdev != netdev && data->physdev != netdev) {
             continue;
         }
-        if (data->creation_tid == tid) {
+        if (data->creation_tid == tid && data->netdev->hw_info.is_deleting) {
+            VLOG_INFO("Remove offloaded dpdk flows for netdev %s",
+                      netdev_get_name(netdev));
             netdev_offload_dpdk_flow_destroy(data);
         }
     }

--- a/lib/netdev-offload.h
+++ b/lib/netdev-offload.h
@@ -51,6 +51,7 @@ struct netdev_hw_info {
     int offload_count;  /* Pending (non-offloaded) flow count */
     int pending_count;  /* Offloaded flow count */
     OVSRCU_TYPE(void *) offload_data; /* Offload metadata. */
+    bool is_deleting;
 };
 
 enum hw_info_type {

--- a/lib/netdev.c
+++ b/lib/netdev.c
@@ -431,6 +431,7 @@ netdev_open(const char *name, const char *type, struct netdev **netdevp)
                     seq_read(netdev->reconfigure_seq);
                 ovsrcu_set(&netdev->flow_api, NULL);
                 netdev->hw_info.oor = false;
+                netdev->hw_info.is_deleting = false;
                 atomic_init(&netdev->hw_info.miss_api_supported, false);
                 netdev->node = shash_add(&netdev_shash, name, netdev);
 


### PR DESCRIPTION
In ret_flow offloading environment, we met a strange behavior. When deleting a netdev port, the offloaded flows of other ports (with running streams) will be unexpectedly removed. And new offloaded flows were not added anymore.

So let's gdb it, when delete a netdev port, we have a call stack like this: -> port_del
-> dpif_netdev_port_del
-> do_del_port
-> dp_netdev_offload_flush

In this ``dp_netdev_offload_flush`` function, it will call ``dp_netdev_offload_flush_enqueue`` to add DP_OFFLOAD_FLUSH items to the offloading queue. Then this thread hits the barrier, and switching to the offloading thread.

The offloading thread will do the following works: -> dp_netdev_flow_offload_main
-> dp_offload_flush
-> netdev_flow_flush
-> netdev_flow_api.flow_flush(netdev_offload_dpdk_flow_flush) 
It will run the following code:

        if (data->netdev != netdev && data->physdev != netdev) {
            continue;
        }
        if (data->creation_tid == tid) {
            netdev_offload_dpdk_flow_destroy(data);
        }

Because offloading can be only available to one physdev, offloaded items have flows belong to other ports, so ``netdev_offload_dpdk_flow_destroy`` will remove those offloaded flows for the running ports. Added a INFO log before the ``netdev_offload_dpdk_flow_destroy`` which proves these behaviors.

        if (data->creation_tid == tid) {
            VLOG_INFO("Remove offloaded dpdk flows for netdev %s",
                      netdev_get_name(netdev));
            netdev_offload_dpdk_flow_destroy(data);
        }

Logs are like this:
    INFO|Remove offloaded dpdk flows for netdev vdpb519e956-17
    INFO|Remove offloaded dpdk flows for netdev vdpb519e956-17
    INFO|Remove offloaded dpdk flows for netdev vdpb519e956-17
    INFO|Remove offloaded dpdk flows for netdev vdpb519e956-17
    INFO|Remove offloaded dpdk flows for netdev ens10f0
    INFO|Remove offloaded dpdk flows for netdev ens10f0
    INFO|Remove offloaded dpdk flows for netdev ens10f0
    INFO|Remove offloaded dpdk flows for netdev ens10f0

The LOG count is equal to the offloaded flows of 4 UDP streams (4 for ingress, 4 for egress).

This patch adds a ``is_deleting`` attribute to the netdev.hw_info. It is initialized to false. In the ``dp_netdev_offload_flush``, it will be set to true. And in the ``netdev_offload_dpdk_flow_destroy``, it will check if the netdev->hw_info.is_deleting.
Then, the running ports' flows will be remained.

Signed-off-by: LIU Yulong <i@liuyulong.me>