### PR TITLE
Correctly parse geneve tunnels

### DIFF
--- a/ipsec/ovs-monitor-ipsec.in
+++ b/ipsec/ovs-monitor-ipsec.in
@@ -261,9 +261,14 @@ conn prevent_unencrypted_vxlan
             tunnel_name = line.split(":")
             if len(tunnel_name) < 2:
                 continue
-            m = re.match(r"(.*)(-in-\d+|-out-\d+|-\d+).*", tunnel_name[0])
+
+            m = re.match(r"(.*)(-in-\d+|-out-\d+)", conn)
+            if not m:
+                # GRE connections have format <iface>-<ver>
+                m = re.match(r"(.*)(-\d+)", conn)
             if not m:
                 continue
+
             ifname = m.group(1)
             if ifname not in conns:
                 conns[ifname] = {}


### PR DESCRIPTION
This is in response to an email I sent earlier. I now have a better understanding of the problem.

There is a bug in `ovs-monitor-ipsec` when it parses the output of `ipsec status`. It uses it to collect existing tunnel connections in order to remove outdated ones whenever there is a change in ovs.

However, the regex it uses - `r"(.*)(-in-\d+|-out-\d+|-\d+).*"` - only works on GRE type of tunnels. This is because the first group matches eagerly and will thus match any `-in-` or `-out-` in the connection's name.

For GRE this is not a problem because it doesn't use separate in/out tunnels, but for the others it does.

As a consequence when using ipsec on any other tunnel than GRE it wrongfully concludes the existing connections are outdated and actively removes them whenever a change happens in ovs' southbound database. Only to add them back shortly thereafter. This results in loss of connectivity.

The solution isn't straight forward, because, in the case of GRE, if they happen to have `-in` or `-out` in their name (which isn't prohibited) you *want* that to be part of the match, but in the case of all other tunnel types, you want to skip over it.

The solution in this PR is to make the first group eager.

That is only a partial solution however, since any GRE tunnel with `-in` or `-out` in their name will get parse incorrectly.