### PR TITLE
emc_insert: fix the bug of wrong replacement

### DIFF
--- a/lib/dpif-netdev.c
+++ b/lib/dpif-netdev.c
@@ -3421,7 +3421,7 @@ emc_insert(struct emc_cache *cache, const struct netdev_flow_key *key,
         if (!to_be_replaced
             || (emc_entry_alive(to_be_replaced)
                 && !emc_entry_alive(current_entry))
-            || current_entry->key.hash < to_be_replaced->key.hash) {
+            || (emc_entry_alive(to_be_replaced) && current_entry->key.hash < to_be_replaced->key.hash)) {
             to_be_replaced = current_entry;
         }
     }


### PR DESCRIPTION
In original implementation, when the first entry is alive, the second entry is not alive and the hash value of the second entry is less than the first, the replacement will occur on the second entry. This commit fix the problem.