### PR TITLE
Bugfix of ovs-tcpdump.

### DIFF
--- a/utilities/ovs-tcpdump.in
+++ b/utilities/ovs-tcpdump.in
@@ -96,6 +96,10 @@ def _install_dst_if_linux(tap_name, mtu_value=None):
         *(['ip', 'link', 'set', 'dev', str(tap_name), 'up']))
     pipe.wait()
 
+    pipe = _doexec(
+        *(['ip', '-6', 'addr', 'flush', 'dev', str(tap_name)]))
+    pipe.wait()
+
 
 def _remove_dst_if_linux(tap_name):
     _doexec(


### PR DESCRIPTION
This bug will cause megaflow action wrong.
For detail discuss, refer email of ovs-discuss titled in "[BUG] [ovs-tcpdump] Got duplicate ...".