### PR TITLE
Fixed troff warning in versions above groff-1.23

### DIFF
--- a/lib/ovs.tmac
+++ b/lib/ovs.tmac
@@ -175,7 +175,7 @@
 .  nr mE \\n(.f
 .  nf
 .  nh
-.  ft CW
+.  ft CR
 ..
 .
 .


### PR DESCRIPTION
- **There are problems:**

When the compilation dependency is groff-1.23, the following message is displayed in the compilation log, and the compilation fails:
```
make[1]: Entering directory '/builddir/build/BUILD/openvswitch-3.1.1/build'
troff:vswitchd/ovs-vswitchd.8:1298: warning: cannot select font 'CW'
make[1]: Leaving directory '/builddir/build/BUILD/openvswitch-3.1.1/build'
make[1]: *** [Makefile:6761: manpage-check] Error 1
```
The full build log is here：https://[build.stream.opencloudos.tech/kojifiles/work/tasks/5893/35893/build.log](https://build.stream.opencloudos.tech/kojifiles/work/tasks/5893/35893/build.log)

- **How to reproduce:**

Install groff-1.23.0 and perform the make operation on the Makefile.

I found this problem during the %build process when compiling openvswitch.spec.

- **Solution:**

I check submitted records of groff (https://git.savannah.gnu.org/cgit/groff.git/commit/?id=d75ea8b2e283e37bd560e821fa4597065f36725f), and found out  they removed the "CW" font. 
openvswitch is still using "CW" here, so I think it needs to be tweaked here. You can substitute ".ft CR" or ".ft R", depending on which font you want to use. 
I temporarily use ".ft R "here. If you need, I can adjust my code.