### PR TITLE
debian: Fix incorrect use of link-time optimizer.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 # -*- makefile -*-
 #export DH_VERBOSE=1
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-export DEB_CFLAGS_MAINT_APPEND = -fPIC
+export DEB_CFLAGS_MAINT_APPEND = -fPIC -fno-lto
 
 %:
 	dh $@


### PR DESCRIPTION
Current version of debian/rules simply uses the default lto GCC optimization settings during the linkage process.

The main problem with this approach is that GCC on OS like Debian Jammy, for example, can enable the -flto=auto option during the openvswitch building and linking process. In this case, the linked dynamic libraries would need to be builded based on the same lto optimization options, at the risk of not working, according to documentation [1].

I'm not sure of the real benefits of using this link-time optimization option, and since when it is enabled it causes problems with shared libs link libjemalloc, for example, it seems safer overwritten compiler decision by passing -fno-lto command.

[1] https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-flto

Reported-at: https://bugs.launchpad.net/ubuntu/+source/openvswitch/+bug/2015748