### PR TITLE
tests: using ulimit to ignore coredump.

### DIFF
--- a/tests/daemon-py.at
+++ b/tests/daemon-py.at
@@ -42,7 +42,11 @@ check_ancestors $child $monitor
 
 # Kill the daemon process, making it look like a segfault,
 # and wait for a new child process to get spawned.
+AT_CHECK([ulimit -c > rlimit.core])
+AT_CHECK([ulimit -c 0])
 AT_CHECK([kill -SEGV $child])
+AT_CHECK([ulimit -c `cat rlimit.core`])
+AT_CHECK([rm rlimit.core])
 OVS_WAIT_WHILE([kill -0 $child])
 OVS_WAIT_UNTIL([test -s $pidfile && test $(cat $pidfile) != $child])
 child2=$(cat $pidfile)
@@ -137,7 +141,11 @@ check_ancestors $child $monitor 1
 
 # Kill the daemon process, making it look like a segfault,
 # and wait for a new daemon process to get spawned.
+AT_CHECK([ulimit -c > rlimit.core])
+AT_CHECK([ulimit -c 0])
 AT_CHECK([kill -SEGV $child])
+AT_CHECK([ulimit -c `cat rlimit.core`])
+AT_CHECK([rm rlimit.core])
 OVS_WAIT_WHILE([kill -0 $child])
 OVS_WAIT_UNTIL([test -s $pidfile && test $(cat $pidfile) != $child])
 child2=$(cat $pidfile)

--- a/tests/daemon.at
+++ b/tests/daemon.at
@@ -105,7 +105,11 @@ OVS_WAIT_UNTIL([ovs-appctl -t ovsdb-server version])
 
 # Kill the daemon process, making it look like a segfault,
 # and wait for a new child process to get spawned.
+AT_CHECK([ulimit -c > rlimit.core])
+AT_CHECK([ulimit -c 0])
 AT_CHECK([kill -SEGV $child], [0], [], [ignore])
+AT_CHECK([ulimit -c `cat rlimit.core`])
+AT_CHECK([rm rlimit.core])
 OVS_WAIT_WHILE([kill -0 $child])
 OVS_WAIT_UNTIL([test -s ovsdb-server.pid && test $(cat ovsdb-server.pid) != $child])
 
@@ -173,7 +177,11 @@ check_ancestors $child $monitor 1
 
 # Kill the daemon process, making it look like a segfault,
 # and wait for a new daemon process to get spawned.
+AT_CHECK([ulimit -c > rlimit.core])
+AT_CHECK([ulimit -c 0])
 AT_CHECK([kill -SEGV $child], [0])
+AT_CHECK([ulimit -c `cat rlimit.core`])
+AT_CHECK([rm rlimit.core])
 OVS_WAIT_WHILE([kill -0 $child])
 OVS_WAIT_UNTIL([test -s ovsdb-server.pid && test `cat ovsdb-server.pid` != $child])
 child2=$(cat ovsdb-server.pid)

--- a/tests/library.at
+++ b/tests/library.at
@@ -226,8 +226,14 @@ else
   # SIGABRT + 128
   exit_status=134
 fi
+
+AT_CHECK([ulimit -c > rlimit.core])
+AT_CHECK([ulimit -c 0])
 AT_CHECK([ovstest test-util -voff -vfile:info '-vPATTERN:file:%c|%p|%m' --log-file assert],
   [$exit_status], [], [stderr])
+AT_CHECK([ulimit -c `cat rlimit.core`])
+AT_CHECK([rm rlimit.core])
+
 
 AT_CHECK([sed 's/\(opened log file\) .*/\1/
 s/|[[^|]]*: /|/' test-util.log], [0], [dnl

--- a/tests/ovsdb-server.at
+++ b/tests/ovsdb-server.at
@@ -326,7 +326,11 @@ ordinals
 # Kill the daemon process, making it look like a segfault,
 # and wait for a new daemon process to get spawned.
 cp ovsdb-server.pid old.pid
+AT_CHECK([ulimit -c > rlimit.core])
+AT_CHECK([ulimit -c 0])
 AT_CHECK([kill -SEGV `cat ovsdb-server.pid`])
+AT_CHECK([ulimit -c `cat rlimit.core`])
+AT_CHECK([rm rlimit.core])
 OVS_WAIT_WHILE([kill -0 `cat old.pid`])
 OVS_WAIT_UNTIL(
   [test -s ovsdb-server.pid && test `cat ovsdb-server.pid` != `cat old.pid`])
@@ -367,7 +371,11 @@ CHECK_DBS([ordinals
 # Kill the daemon process, making it look like a segfault,
 # and wait for a new daemon process to get spawned.
 cp ovsdb-server.pid old.pid
+AT_CHECK([ulimit -c > rlimit.core])
+AT_CHECK([ulimit -c 0])
 AT_CHECK([kill -SEGV `cat ovsdb-server.pid`])
+AT_CHECK([ulimit -c `cat rlimit.core`])
+AT_CHECK([rm rlimit.core])
 OVS_WAIT_WHILE([kill -0 `cat old.pid`])
 OVS_WAIT_UNTIL(
   [test -s ovsdb-server.pid && test `cat ovsdb-server.pid` != `cat old.pid`])
@@ -529,7 +537,11 @@ AT_CHECK([ovs-appctl -t ovsdb-server ovsdb-server/list-remotes],
 # start listening on 'socket1'.
 cp ovsdb-server.pid old.pid
 rm socket1
+AT_CHECK([ulimit -c > rlimit.core])
+AT_CHECK([ulimit -c 0])
 AT_CHECK([kill -SEGV `cat ovsdb-server.pid`])
+AT_CHECK([ulimit -c `cat rlimit.core`])
+AT_CHECK([rm rlimit.core])
 OVS_WAIT_WHILE([kill -0 `cat old.pid`])
 OVS_WAIT_UNTIL(
   [test -s ovsdb-server.pid && test `cat ovsdb-server.pid` != `cat old.pid`])
@@ -575,7 +587,11 @@ AT_CHECK([ovs-appctl -t ovsdb-server ovsdb-server/list-remotes])
 # and wait for a new daemon process to get spawned and make sure that it
 # does not listen on 'socket1'.
 cp ovsdb-server.pid old.pid
+AT_CHECK([ulimit -c > rlimit.core])
+AT_CHECK([ulimit -c 0])
 AT_CHECK([kill -SEGV `cat ovsdb-server.pid`])
+AT_CHECK([ulimit -c `cat rlimit.core`])
+AT_CHECK([rm rlimit.core])
 OVS_WAIT_WHILE([kill -0 `cat old.pid`])
 OVS_WAIT_UNTIL(
   [test -s ovsdb-server.pid && test `cat ovsdb-server.pid` != `cat old.pid`])


### PR DESCRIPTION
Some testcases simulating a fault with kill command, that might cause system generate a coredump file.
Using ulimit to disable coredump before that testcases and restore them after testing.