### PR TITLE
ofproto: Fix NULL deref reported by Coverity.

### DIFF
--- a/ofproto/ofproto.c
+++ b/ofproto/ofproto.c
@@ -800,7 +800,7 @@ ofproto_type_set_config(const char *datapath_type, const struct smap *cfg)
     datapath_type = ofproto_normalize_type(datapath_type);
     class = ofproto_class_find__(datapath_type);
 
-    if (class->type_set_config) {
+    if (class && class->type_set_config) {
         class->type_set_config(datapath_type, cfg);
     }
 }


### PR DESCRIPTION
Ofproto_class_find__() may return NULL, and dereference it to cause segfault.

Tested-by: Zhang YuHuang <zhangyuhuang@ruijie.com.cn>
Signed-off-by: Lin Huang <linhuang@ruijie.com.cn>